### PR TITLE
Feat: Decouple Model Definitions using Host config Hook

### DIFF
--- a/packages/opencode/src/plugin.ts
+++ b/packages/opencode/src/plugin.ts
@@ -1464,7 +1464,7 @@ export const createAntigravityPlugin = (providerId: string) => async (
 
   return {
     config: async (opencodeConfig: Record<string, unknown>) => {
-      applyAntigravityProviderCatalog(opencodeConfig, providerId);
+      applyAntigravityProviderCatalog(opencodeConfig, providerId, config);
       const mutableConfig = opencodeConfig as Record<string, unknown> & {
         command?: Record<string, unknown>;
       };
@@ -3851,16 +3851,29 @@ type OpencodeMutableConfig = Record<string, unknown> & {
   }>;
 };
 
-function applyAntigravityProviderCatalog(config: Record<string, unknown>, providerId: string): void {
-  const mutableConfig = config as OpencodeMutableConfig;
+function applyAntigravityProviderCatalog(
+  opencodeConfig: Record<string, unknown>,
+  providerId: string,
+  pluginConfig: AntigravityConfig
+): void {
+  const mutableConfig = opencodeConfig as OpencodeMutableConfig;
   mutableConfig.provider ??= {};
 
   const providerConfig = mutableConfig.provider[providerId] ?? {};
+  
+  // Merge order (lowest to highest priority):
+  // 1. Built-in defaults: OPENCODE_MODEL_DEFINITIONS
+  // 2. Decoupled models (from antigravity.json / antigravity-models.json): pluginConfig.models
+  // 3. User's main opencode.json models (preserves backwards compatibility / custom overrides)
   providerConfig.models = {
-    ...(providerConfig.models ?? {}),
     ...OPENCODE_MODEL_DEFINITIONS,
+    ...(pluginConfig.models ?? {}),
+    ...(providerConfig.models ?? {}),
   };
-  providerConfig.whitelist = getAntigravityOpencodeModelIds();
+  
+  // Whitelist should be the union of all registered models so they aren't pruned by OpenCode
+  providerConfig.whitelist = Object.keys(providerConfig.models);
+  
   mutableConfig.provider[providerId] = providerConfig;
 }
 

--- a/packages/opencode/src/plugin/config/loader.ts
+++ b/packages/opencode/src/plugin/config/loader.ts
@@ -112,12 +112,56 @@ function mergeConfigs(
 // Main Loader
 // =============================================================================
 
-/**
- * Load the complete configuration.
- * 
- * @param directory - The project directory (for project-level config)
- * @returns Fully resolved configuration
- */
+function stripJsonCommentsAndTrailingCommas(json: string): string {
+  return json
+    .replace(
+      /\\"|"(?:\\"|[^"])*"|(\/\/.*|\/\*[\s\S]*?\*\/)/g,
+      (match: string, group: string | undefined) => (group ? "" : match)
+    )
+    .replace(/,(\s*[}\]])/g, "$1");
+}
+
+function loadModelsFile(path: string): Record<string, any> | null {
+  try {
+    if (!existsSync(path)) {
+      return null;
+    }
+    const content = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(stripJsonCommentsAndTrailingCommas(content));
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed;
+    }
+    return null;
+  } catch (error) {
+    log.warn("Failed to load decoupled models file", { path, error: String(error) });
+    return null;
+  }
+}
+
+export function loadDecoupledModels(directory: string): Record<string, any> {
+  let mergedModels: Record<string, any> = {};
+
+  const configDir = getConfigDir();
+  const userJsonPath = join(configDir, "antigravity-models.json");
+  const userJsoncPath = join(configDir, "antigravity-models.jsonc");
+  const projectJsonPath = join(directory, ".opencode", "antigravity-models.json");
+  const projectJsoncPath = join(directory, ".opencode", "antigravity-models.jsonc");
+
+  // User level (prefer jsonc if both exist)
+  const userModels = loadModelsFile(existsSync(userJsoncPath) ? userJsoncPath : userJsonPath);
+  if (userModels) {
+    mergedModels = { ...mergedModels, ...userModels };
+  }
+
+  // Project level (prefer jsonc if both exist) - overrides user level
+  const projectModels = loadModelsFile(existsSync(projectJsoncPath) ? projectJsoncPath : projectJsonPath);
+  if (projectModels) {
+    mergedModels = { ...mergedModels, ...projectModels };
+  }
+
+  return mergedModels;
+}
+
 export function loadConfig(directory: string): AntigravityConfig {
   // Start with defaults
   let config: AntigravityConfig = { ...DEFAULT_CONFIG };
@@ -134,6 +178,15 @@ export function loadConfig(directory: string): AntigravityConfig {
   const projectConfig = loadConfigFile(projectConfigPath);
   if (projectConfig) {
     config = mergeConfigs(config, projectConfig);
+  }
+
+  // Load decoupled models from antigravity-models.json(c) and merge into config.models
+  const decoupledModels = loadDecoupledModels(directory);
+  if (Object.keys(decoupledModels).length > 0) {
+    config.models = {
+      ...(config.models ?? {}),
+      ...decoupledModels,
+    };
   }
 
   return config;

--- a/packages/opencode/src/plugin/config/schema.ts
+++ b/packages/opencode/src/plugin/config/schema.ts
@@ -503,6 +503,11 @@ export const AntigravityConfigSchema = z.object({
    */
   auto_update: z.boolean().default(true),
 
+  /**
+   * Decoupled model definitions to inject.
+   */
+  models: z.record(z.string(), z.any()).optional(),
+
 });
 
 export type AntigravityConfig = z.infer<typeof AntigravityConfigSchema>;


### PR DESCRIPTION
### Feat: Decouple Model Definitions using Host `config` Hook

This PR implements a solution to decouple model definitions from the user's primary `opencode.json` configuration file, reducing configuration bloat and resolving maintenance issues discussed in #134.

#### The Hook Mechanism
By targeting OpenCode's runtime `config` lifecycle hook, which executes **prior** to provider validation and client instantiation, the plugin dynamically injects model catalogs directly into OpenCode's configuration memory. 

This enables:
1. Zero-configuration setups: model updates are registered automatically on plugin updates.
2. Separation of concerns: user-level overrides or custom configurations are kept out of `opencode.json`.

#### What's Changed
- **Multi-Source Model Resolution**: Added support for reading custom model declarations from:
  - `~/.config/opencode/antigravity-models.json(c)`
  - `.opencode/antigravity-models.json(c)`
  - The `models` mapping block in `antigravity.json`.
- **Precedence-Aware Merging (Backwards Compatible)**: We enforce a priority order:
  `Built-in defaults` -> `Decoupled JSON/JSONC overrides` -> `Main opencode.json overrides`
  This ensures any existing model declarations inside `opencode.json` continue to override all other definitions, ensuring zero disruption for existing users.
- **Dynamic Whitelisting**: The plugin no longer relies on a hardcoded array of whitelisted model IDs, instead compiling the whitelist dynamically from the keys of the final merged model dictionary.

#### Why Backwards Compatibility Matters (Fail-Safe Architecture)
Because OpenCode's `config` lifecycle hook is currently undocumented, there is a risk that a future upstream OpenCode release could deprecate or alter it. 

To mitigate this, we maintain full backwards compatibility with static definitions in `opencode.json`:
1. **Fallback Path**: If the hook is deprecated or disabled, users can fall back to pasting the model definitions into `opencode.json` (or using the `opencode auth login` model setup flow). OpenCode will parse them natively.
2. **Override Priority**: By merging `opencode.json` definitions last, we guarantee that any static config file settings override the dynamic injection, leaving the user in complete control.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/antigravity-auth/pr/4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784550736&installation_id=135454708&pr_number=4&repository=cortexkit%2Fantigravity-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fantigravity-auth%2Fpull%2F4&signature=32c9c1b48c4af35bb55291f17732700907d1ac98a11da3620cb57e26fba0274e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decouples model definitions from the main OpenCode config by injecting them during the host `config` hook. This reduces `opencode.json` bloat and enables zero‑config model updates.

- **New Features**
  - Load decoupled model files from `~/.config/opencode/antigravity-models.json(c)` and `./.opencode/antigravity-models.json(c)` (JSON/JSONC supported).
  - Merge precedence: built‑ins → decoupled models → `opencode.json` overrides (backward compatible).
  - Inject merged models into the provider config and set `whitelist` to all merged model IDs.
  - Add optional `models` in the plugin config schema to carry injected definitions.

<sup>Written for commit fe739e8f226fa6e7255e9decce5f7a4d89eb5553. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/antigravity-auth/pull/4?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

