### PR TITLE
feat: add Gemini 3.1 Flash Lite model

### DIFF
--- a/packages/core/src/model-registry.test.ts
+++ b/packages/core/src/model-registry.test.ts
@@ -30,6 +30,7 @@ describe('model registry', () => {
       'antigravity-claude-opus-4-6-thinking',
       'antigravity-claude-sonnet-4-6-thinking',
       'antigravity-gemini-3.1-flash-image',
+      'antigravity-gemini-3.1-flash-lite',
       'antigravity-gemini-3.1-pro',
       'antigravity-gemini-3.5-flash',
       'antigravity-gemini-3.6-flash',
@@ -102,6 +103,16 @@ describe('model registry', () => {
         input: ['text', 'image'],
         output: ['text', 'image'],
       },
+    })
+  })
+
+  it('registers flash-lite as a non-thinking text model', () => {
+    expect(
+      getPublicModelDefinitions()['antigravity-gemini-3.1-flash-lite'],
+    ).toMatchObject({
+      reasoning: false,
+      limit: { context: 1048576, output: 65535 },
+      modalities: { input: ['text'], output: ['text'] },
     })
   })
 })

--- a/packages/core/src/model-registry.ts
+++ b/packages/core/src/model-registry.ts
@@ -104,6 +104,15 @@ const ALL_MODEL_DEFINITIONS: OpencodeModelDefinitions = {
       high: { thinkingLevel: 'high' },
     },
   }),
+  'antigravity-gemini-3.1-flash-lite': defineModel(
+    'antigravity-gemini-3.1-flash-lite',
+    {
+      name: 'Gemini 3.1 Flash Lite (Antigravity)',
+      reasoning: false,
+      limit: { context: 1048576, output: 65535 },
+      modalities: { input: ['text'], output: ['text'] },
+    },
+  ),
   'antigravity-gemini-3.6-flash': defineModel('antigravity-gemini-3.6-flash', {
     name: 'Gemini 3.6 Flash (Antigravity)',
     reasoning: true,
@@ -291,6 +300,7 @@ const QUOTA_GROUP_BY_MODEL_ID: Record<string, ModelQuotaGroup> = {
   'gemini-3.1-pro-high': 'gemini-pro',
   'gemini-3-flash': 'gemini-flash',
   'gemini-3-flash-agent': 'gemini-flash',
+  'gemini-3.1-flash-lite': 'gemini-flash',
   'gemini-3.5-flash-low': 'gemini-flash',
   'gemini-3.5-flash-extra-low': 'gemini-flash',
   'gemini-3.6-flash-low': 'gemini-flash',
@@ -304,6 +314,7 @@ const QUOTA_GROUP_BY_MODEL_ID: Record<string, ModelQuotaGroup> = {
 
 const ANTIGRAVITY_OPENCODE_MODEL_IDS = [
   'antigravity-gemini-3.6-flash',
+  'antigravity-gemini-3.1-flash-lite',
   'antigravity-gemini-3.5-flash',
   'antigravity-gemini-3.1-pro',
   'antigravity-claude-sonnet-4-6-thinking',

--- a/packages/core/src/transform/model-resolver.test.ts
+++ b/packages/core/src/transform/model-resolver.test.ts
@@ -74,6 +74,28 @@ describe('resolveModelWithTier', () => {
     })
   })
 
+  describe('Gemini 3.1 Flash Lite Antigravity route', () => {
+    it('resolves as a non-thinking text model', () => {
+      const result = resolveModelWithTier('antigravity-gemini-3.1-flash-lite')
+      expect(result.actualModel).toBe('gemini-3.1-flash-lite')
+      expect(result.isThinkingModel).toBe(false)
+      expect(result.thinkingBudget).toBeUndefined()
+      expect(result.thinkingLevel).toBeUndefined()
+      expect(result.tier).toBeUndefined()
+      expect(result.quotaPreference).toBe('antigravity')
+    })
+
+    it('maps gemini-3.1-flash-lite directly for the header-style path', () => {
+      const result = resolveModelForHeaderStyle(
+        'gemini-3.1-flash-lite',
+        'antigravity',
+      )
+      expect(result.actualModel).toBe('gemini-3.1-flash-lite')
+      expect(result.isThinkingModel).toBe(false)
+      expect(result.quotaPreference).toBe('antigravity')
+    })
+  })
+
   describe('Gemini 3.6 Flash Antigravity routes', () => {
     it.each([
       [

--- a/packages/core/src/transform/model-resolver.test.ts
+++ b/packages/core/src/transform/model-resolver.test.ts
@@ -497,6 +497,18 @@ describe('Issue #103: resolveModelForHeaderStyle', () => {
       expect(result.thinkingLevel).toBe('medium')
       expect(result.quotaPreference).toBe('gemini-cli')
     })
+
+    it('resolves gemini-3.1-flash-lite as non-thinking on gemini-cli path', () => {
+      const result = resolveModelForHeaderStyle(
+        'gemini-3.1-flash-lite',
+        'gemini-cli',
+      )
+      expect(result.actualModel).toBe('gemini-3.1-flash-lite')
+      expect(result.isThinkingModel).toBe(false)
+      expect(result.thinkingLevel).toBeUndefined()
+      expect(result.thinkingBudget).toBeUndefined()
+      expect(result.quotaPreference).toBe('gemini-cli')
+    })
   })
 
   describe('no transformation needed', () => {

--- a/packages/core/src/transform/model-resolver.test.ts
+++ b/packages/core/src/transform/model-resolver.test.ts
@@ -94,6 +94,41 @@ describe('resolveModelWithTier', () => {
       expect(result.isThinkingModel).toBe(false)
       expect(result.quotaPreference).toBe('antigravity')
     })
+
+    // Tier-suffixed flash-lite must NOT carry thinkingLevel / tier on
+    // any quota path — flash-lite does not support thinking.
+    it('drops tier suffix on antigravity header-style path', () => {
+      const result = resolveModelForHeaderStyle(
+        'gemini-3.1-flash-lite-high',
+        'antigravity',
+      )
+      expect(result.actualModel).toBe('gemini-3.1-flash-lite')
+      expect(result.isThinkingModel).toBe(false)
+      expect(result.thinkingLevel).toBeUndefined()
+      expect(result.tier).toBeUndefined()
+      expect(result.quotaPreference).toBe('antigravity')
+    })
+
+    it('drops tier suffix on gemini-cli header-style path', () => {
+      const result = resolveModelForHeaderStyle(
+        'gemini-3.1-flash-lite-high',
+        'gemini-cli',
+      )
+      expect(result.actualModel).toBe('gemini-3.1-flash-lite')
+      expect(result.isThinkingModel).toBe(false)
+      expect(result.thinkingLevel).toBeUndefined()
+      expect(result.tier).toBeUndefined()
+      expect(result.quotaPreference).toBe('gemini-cli')
+    })
+
+    it('drops tier suffix on direct resolveModelWithTier call', () => {
+      const result = resolveModelWithTier('gemini-3.1-flash-lite-high')
+      expect(result.actualModel).toBe('gemini-3.1-flash-lite')
+      expect(result.isThinkingModel).toBe(false)
+      expect(result.thinkingLevel).toBeUndefined()
+      expect(result.tier).toBeUndefined()
+      expect(result.quotaPreference).toBe('antigravity')
+    })
   })
 
   describe('Gemini 3.6 Flash Antigravity routes', () => {

--- a/packages/core/src/transform/model-resolver.ts
+++ b/packages/core/src/transform/model-resolver.ts
@@ -250,7 +250,8 @@ export function resolveModelWithTier(
     }
   }
 
-  if (isGemini31FlashLite && quotaPreference === 'antigravity') {
+  // Flash-lite is text-only and non-thinking on every quota path.
+  if (isGemini31FlashLite) {
     return {
       actualModel: 'gemini-3.1-flash-lite',
       isThinkingModel: false,
@@ -470,8 +471,15 @@ export function resolveModelForHeaderStyle(
     // gemini-3-flash-preview bucket; retrieveUserQuota does not list a
     // gemini-3.5-flash bucket for the gemini-cli header path.
     const isGemini35Flash = isGemini35FlashModel(transformedModel)
+    // Flash-lite has no -preview CLI variant — keep the plain wire id.
+    const isGemini31FlashLite = /^gemini-3\.1-flash-lite$/i.test(
+      transformedModel,
+    )
     if (isGemini35Flash) {
       transformedModel = getGemini35FlashGeminiCliFallbackModel()
+    } else if (isGemini31FlashLite) {
+      // No transformation needed — flash-lite resolves as non-thinking
+      // and has no distinct CLI preview model.
     } else if (!hasPreviewSuffix) {
       transformedModel = `${transformedModel}-preview`
     }

--- a/packages/core/src/transform/model-resolver.ts
+++ b/packages/core/src/transform/model-resolver.ts
@@ -214,6 +214,7 @@ export function resolveModelWithTier(
   const isGemini31Pro = /^gemini-3\.1-pro/i.test(baseName)
   const isGemini35Flash = /^gemini-3\.5-flash/i.test(baseName)
   const isGemini36Flash = /^gemini-3\.6-flash/i.test(baseName)
+  const isGemini31FlashLite = /^gemini-3\.1-flash-lite/i.test(baseName)
   const isGptOss120b = /^gpt-oss-120b(?:-medium)?$/i.test(baseName)
 
   if (isGemini31Pro && quotaPreference === 'antigravity') {
@@ -244,6 +245,15 @@ export function resolveModelWithTier(
       thinkingBudget: getAgyGeminiFlashThinkingBudget(tier),
       tier: tier ?? 'medium',
       isThinkingModel: true,
+      quotaPreference,
+      explicitQuota,
+    }
+  }
+
+  if (isGemini31FlashLite && quotaPreference === 'antigravity') {
+    return {
+      actualModel: 'gemini-3.1-flash-lite',
+      isThinkingModel: false,
       quotaPreference,
       explicitQuota,
     }
@@ -428,11 +438,15 @@ export function resolveModelForHeaderStyle(
     const isGemini35Flash = isGemini35FlashModel(
       transformedModel.replace(TIER_REGEX, ''),
     )
+    const isGemini31FlashLite = /^gemini-3\.1-flash-lite/i.test(
+      transformedModel,
+    )
 
-    // Don't add tier suffix to image models - they don't support thinking
+    // Don't add tier suffix to image or flash-lite models - they don't support thinking
     if (
       (isGemini3Pro || isGemini3Flash) &&
       !isGemini35Flash &&
+      !isGemini31FlashLite &&
       !hasTierSuffix &&
       !isImageModel
     ) {

--- a/packages/core/src/transform/model-resolver.ts
+++ b/packages/core/src/transform/model-resolver.ts
@@ -485,6 +485,16 @@ export function resolveModelForHeaderStyle(
     }
 
     const resolved = resolveModelWithTier(transformedModel, { cli_first: true })
+
+    // Flash-lite is non-thinking — don't pass through requestedTier even if a
+    // tier suffix was on the original request.
+    if (isGemini31FlashLite) {
+      return {
+        ...resolved,
+        quotaPreference: 'gemini-cli',
+      }
+    }
+
     return {
       ...resolved,
       thinkingLevel: requestedTier ?? resolved.thinkingLevel,

--- a/packages/opencode/script/test-models.ts
+++ b/packages/opencode/script/test-models.ts
@@ -15,6 +15,10 @@ const MODELS: ModelTest[] = [
 
   // Antigravity Gemini
   {
+    model: 'google/antigravity-gemini-3.1-flash-lite',
+    category: 'antigravity-gemini',
+  },
+  {
     model: 'google/antigravity-gemini-3.6-flash-low',
     category: 'antigravity-gemini',
   },

--- a/packages/opencode/src/plugin/config/models.test.ts
+++ b/packages/opencode/src/plugin/config/models.test.ts
@@ -18,6 +18,7 @@ describe('OPENCODE_MODEL_DEFINITIONS', () => {
       'antigravity-claude-opus-4-6-thinking',
       'antigravity-claude-sonnet-4-6-thinking',
       'antigravity-gemini-3.1-flash-image',
+      'antigravity-gemini-3.1-flash-lite',
       'antigravity-gemini-3.1-pro',
       'antigravity-gemini-3.5-flash',
       'antigravity-gemini-3.6-flash',
@@ -50,6 +51,17 @@ describe('OPENCODE_MODEL_DEFINITIONS', () => {
       reasoning: true,
       limit: { context: 131072, output: 32768 },
     })
+  })
+
+  it('registers flash-lite without thinking variants', () => {
+    expect(getModel('antigravity-gemini-3.1-flash-lite')).toMatchObject({
+      reasoning: false,
+      limit: { context: 1048576, output: 65535 },
+      modalities: { input: ['text'], output: ['text'] },
+    })
+    expect(
+      getModel('antigravity-gemini-3.1-flash-lite').variants,
+    ).toBeUndefined()
   })
 
   it('disables unsupported automatic Claude budget variants', () => {

--- a/packages/opencode/src/plugin/quota.test.ts
+++ b/packages/opencode/src/plugin/quota.test.ts
@@ -53,6 +53,9 @@ describe('classifyQuotaGroup', () => {
         'Gemini 3.6 Flash (Medium)',
       ),
     ).toBe('gemini-flash')
+    expect(
+      classifyQuotaGroup('gemini-3.1-flash-lite', 'Gemini 3.1 Flash Lite'),
+    ).toBe('gemini-flash')
     expect(classifyQuotaGroup('gemini-pro-agent', 'Gemini 3.1 Pro')).toBe(
       'gemini-pro',
     )

--- a/packages/opencode/src/plugin/request.test.ts
+++ b/packages/opencode/src/plugin/request.test.ts
@@ -1611,6 +1611,33 @@ describe('request.ts', () => {
       })
     })
 
+    it('builds the AGY 1.1.6 request for gemini-3.1-flash-lite as a non-thinking model', () => {
+      const result = prepareAntigravityRequest(
+        'https://generativelanguage.googleapis.com/v1beta/models/antigravity-gemini-3.1-flash-lite:generateContent',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            contents: [
+              { role: 'user', parts: [{ text: 'Reply with FLASHLITE_OK' }] },
+            ],
+            generationConfig: { maxOutputTokens: 1024 },
+          }),
+        },
+        mockAccessToken,
+        mockProjectId,
+        undefined,
+        'antigravity',
+      )
+
+      const wrapped = JSON.parse(result.init.body as string)
+      expect(result.effectiveModel).toBe('gemini-3.1-flash-lite')
+      expect(wrapped.model).toBe('gemini-3.1-flash-lite')
+      expect(wrapped.request.generationConfig).toMatchObject({
+        maxOutputTokens: 65535,
+      })
+      expect(wrapped.request.generationConfig.thinkingConfig).toBeUndefined()
+    })
+
     it('builds the live Gemini 3.1 Flash Image request shape', () => {
       const result = prepareAntigravityRequest(
         'https://generativelanguage.googleapis.com/v1beta/models/antigravity-gemini-3.1-flash-image:generateContent',

--- a/packages/opencode/src/plugin/request.ts
+++ b/packages/opencode/src/plugin/request.ts
@@ -202,6 +202,9 @@ function getAgyMaxOutputTokens(model: string): number | undefined {
   ) {
     return 65536
   }
+  if (lower === 'gemini-3.1-flash-lite') {
+    return 65535
+  }
   if (lower === 'gemini-3.1-pro-low' || lower === 'gemini-pro-agent') {
     return 65535
   }

--- a/packages/pi/src/index.test.ts
+++ b/packages/pi/src/index.test.ts
@@ -14,6 +14,7 @@ describe('Pi Antigravity model catalog', () => {
         models: Array<{
           id: string
           reasoning: boolean
+          input: Array<string>
           contextWindow: number
           maxTokens: number
         }>
@@ -25,15 +26,15 @@ describe('Pi Antigravity model catalog', () => {
     expect(modelIds).toContain('antigravity-gemini-3.6-flash')
     expect(modelIds).toContain('antigravity-gpt-oss-120b-medium')
     expect(modelIds).not.toContain('antigravity-gemini-3.1-flash-image')
-    expect(
-      config.models.find(
-        (model) => model.id === 'antigravity-gemini-3.1-flash-lite',
-      ),
-    ).toMatchObject({
+    const flashLite = config.models.find(
+      (model) => model.id === 'antigravity-gemini-3.1-flash-lite',
+    )
+    expect(flashLite).toMatchObject({
       reasoning: false,
       contextWindow: 1048576,
       maxTokens: 65535,
     })
+    expect(flashLite!.input).toEqual(['text'])
     expect(
       config.models.find(
         (model) => model.id === 'antigravity-gemini-3.6-flash',

--- a/packages/pi/src/index.test.ts
+++ b/packages/pi/src/index.test.ts
@@ -21,9 +21,19 @@ describe('Pi Antigravity model catalog', () => {
     ]
     const modelIds = config.models.map((model) => model.id)
 
+    expect(modelIds).toContain('antigravity-gemini-3.1-flash-lite')
     expect(modelIds).toContain('antigravity-gemini-3.6-flash')
     expect(modelIds).toContain('antigravity-gpt-oss-120b-medium')
     expect(modelIds).not.toContain('antigravity-gemini-3.1-flash-image')
+    expect(
+      config.models.find(
+        (model) => model.id === 'antigravity-gemini-3.1-flash-lite',
+      ),
+    ).toMatchObject({
+      reasoning: false,
+      contextWindow: 1048576,
+      maxTokens: 65535,
+    })
     expect(
       config.models.find(
         (model) => model.id === 'antigravity-gemini-3.6-flash',

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -15,8 +15,15 @@ import { streamCortexKitAntigravity } from './stream.ts'
 
 const ANTIGRAVITY_PROVIDER_ID = 'google-antigravity'
 
-function textImageInput(): Array<'text' | 'image'> {
-  return ['text', 'image']
+/** Derive Pi-compatible input modalities from the model registry, keeping
+ * selectable capabilities consistent with the source of truth.
+ * Pi's protocol only supports 'text' and 'image' input types. */
+function modelInput(modalities: {
+  input: Array<string>
+}): Array<'text' | 'image'> {
+  return modalities.input.filter(
+    (m): m is 'text' | 'image' => m === 'text' || m === 'image',
+  )
 }
 
 async function loginAntigravity(
@@ -84,7 +91,7 @@ export default function cortexKitPiAntigravityAuth(pi: ExtensionAPI): void {
       id: model.id,
       name: model.name,
       reasoning: model.reasoning,
-      input: textImageInput(),
+      input: modelInput(model.modalities),
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       contextWindow: model.limit.context,
       maxTokens: model.limit.output,


### PR DESCRIPTION
Adds `gemini-3.1-flash-lite` — the newest Flash Lite the Antigravity API serves.

## Verified against the live API

`fetchAvailableModels` lists it, and a real `streamGenerateContent` returns HTTP 200 echoing `modelVersion: "gemini-3.1-flash-lite"` — it's a working model, not a placeholder. Metadata from the API: 1,048,576 context / 65,535 max output, `API_PROVIDER_GOOGLE_GEMINI`, non-thinking text model. (The API serves no 3.5/3.6 Flash Lite yet; 3.1 is the current Lite.)

## Changes

Mirrors the existing `gemini-3.6-flash` wiring (commit `a8e4e28`) for a lite text model:

- `model-registry.ts` — model definition, gemini flash quota group, id list
- `transform/model-resolver.ts` — resolves as non-thinking (`isThinkingModel: false`), excluded from the tier-suffix header path
- `plugin/request.ts` — 65,535 max output tokens
- `config` + Pi catalog — selectable as `google/antigravity-gemini-3.1-flash-lite`; exposed in the Pi provider

No thinking-tier or image handling (not applicable to a lite text model).

## Verification

```
unit       1832 pass, 0 fail (+5 new)
e2e        28 pass, 0 fail
typecheck  clean
lint       clean, 0 warnings
```

Note: branched off current `main`, so the model lands in the pre-existing gemini flash quota group. If #8 (the two-pool quota rework) merges first, this collapses into the single `gemini` pool on rebase — a one-line classification adjustment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/antigravity-auth/pr/9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787501214&installation_model_id=22398&pr_number=9&repository=cortexkit%2Fantigravity-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fantigravity-auth%2Fpull%2F9&signature=ad4a0e6ab59a7a32c001b7e8f5294fc387d0ffe089521ff1f2a3fbedba14a498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `gemini-3.1-flash-lite` as a text-only, non-thinking model (1,048,576 context / 65,535 max output). Fully wired across the `opencode` stack; resolves correctly on Antigravity and `gemini-cli` without tiers or preview, and is verified against the live API.

- **New Features**
  - Registered `antigravity-gemini-3.1-flash-lite` with text-only limits; added to Antigravity model IDs and the `gemini-flash` quota group.
  - Resolver maps to `gemini-3.1-flash-lite` as non-thinking on Antigravity and `gemini-cli`, skipping `-preview`.
  - Request builder sets `maxOutputTokens` to 65,535 with no `thinkingConfig`.
  - Exposed as `google/antigravity-gemini-3.1-flash-lite` in the `pi` provider; `pi` now derives input modalities from the registry to keep Flash Lite text-only.

- **Bug Fixes**
  - Drops any `thinkingLevel`/`tier` fields for Flash Lite on all paths, even when a tier suffix is present.

<sup>Written for commit 7115635359baaa17a32f7989ad89d3cd519928ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/antigravity-auth/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

