### PR TITLE
fix(opencode): remove install-breaking upper bounds on shared deps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -48,6 +48,9 @@
       "dependencies": {
         "@cortexkit/antigravity-auth-core": "2.0.0",
         "@openauthjs/openauth": "^0.4.3",
+        "@opentui/core": ">=0.4.5",
+        "@opentui/keymap": ">=0.4.5",
+        "@opentui/solid": ">=0.4.5",
         "jsonc-parser": "^3.3.1",
         "solid-js": "1.9.12",
         "xdg-basedir": "^5.1.0",
@@ -59,10 +62,7 @@
         "zod-to-json-schema": "^3.25.1",
       },
       "peerDependencies": {
-        "@opencode-ai/plugin": "^1.17.13",
-        "@opentui/core": "^0.4.5",
-        "@opentui/keymap": "^0.4.5",
-        "@opentui/solid": "^0.4.5",
+        "@opencode-ai/plugin": "*",
         "typescript": "^5 || ^6",
       },
     },

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -69,10 +69,7 @@
     "test:e2e:regression": "bunx tsx script/test-regression.ts"
   },
   "peerDependencies": {
-    "@opencode-ai/plugin": "^1.17.13",
-    "@opentui/core": "^0.4.5",
-    "@opentui/keymap": "^0.4.5",
-    "@opentui/solid": "^0.4.5",
+    "@opencode-ai/plugin": "*",
     "typescript": "^5 || ^6"
   },
   "devDependencies": {
@@ -83,6 +80,9 @@
   "dependencies": {
     "@cortexkit/antigravity-auth-core": "2.0.0",
     "@openauthjs/openauth": "^0.4.3",
+    "@opentui/core": ">=0.4.5",
+    "@opentui/keymap": ">=0.4.5",
+    "@opentui/solid": ">=0.4.5",
     "jsonc-parser": "^3.3.1",
     "solid-js": "1.9.12",
     "xdg-basedir": "^5.1.0",

--- a/packages/opencode/src/package-manifest.test.ts
+++ b/packages/opencode/src/package-manifest.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Guard the published dependency ranges against install-breaking upper bounds.
+ *
+ * The plugin is installed by `opencode plugin` into a tree that ALREADY
+ * contains the host (`@opencode-ai/plugin`) and its OpenTUI stack. Whenever we
+ * declare a range for a package the host also declares, an upper bound on our
+ * side can make the tree unsatisfiable and npm aborts with ERESOLVE — the
+ * plugin then fails to install at all, which surfaces to the user as a missing
+ * provider ("Model not found: google/antigravity-...").
+ *
+ * That shipped in 2.0.0: `@opentui/*` was declared as `^0.4.5`, which on a 0.x
+ * version means `>=0.4.5 <0.5.0`. OpenTUI released 0.5.0, the host accepted it
+ * via its own `>=0.4.5`, and every fresh install broke.
+ *
+ * The rule these tests encode is narrow and mechanical: a FLOOR is fine (we can
+ * require a minimum), a CEILING is not. `999.0.0` stands in for "any future
+ * release" — a range that rejects it carries an upper bound, whether explicit
+ * (`<2`), tilde (`~0.4.5`), or the implicit caret-on-zero (`^0.4.5`).
+ *
+ * Scope, stated plainly: these are STATIC range assertions. They do not run a
+ * resolver and prove nothing about the shape of an installed tree. The
+ * end-to-end proof that a real install succeeds and dedupes to one copy is
+ * `scripts/smoke-tui-pack-install.ts`, which packs the tarball and installs it
+ * into a throwaway consumer. These tests exist because that smoke test only
+ * exercises the versions present when it runs: it cannot fail for a ceiling no
+ * released version has crossed YET, which is exactly how the 2.0.0 break
+ * reached users. A ceiling is detectable the moment it is written; waiting for
+ * the ecosystem to cross it is what turned this one into a field report.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const PACKAGE_ROOT = resolve(fileURLToPath(import.meta.url), '../../')
+
+interface Manifest {
+  dependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+}
+
+const readManifest = (path: string): Manifest =>
+  JSON.parse(readFileSync(path, 'utf-8')) as Manifest
+
+const ourManifest = readManifest(join(PACKAGE_ROOT, 'package.json'))
+
+/** Every range we publish, regardless of which field declares it. */
+const ourRanges: Record<string, string> = {
+  ...(ourManifest.dependencies ?? {}),
+  ...(ourManifest.peerDependencies ?? {}),
+}
+
+/**
+ * Resolve the host manifest from the installed tree rather than hardcoding a
+ * copy — the point is to compare against whatever host version is in play.
+ */
+const findHostManifest = (): Manifest | null => {
+  let dir = PACKAGE_ROOT
+  for (let depth = 0; depth < 6; depth += 1) {
+    const candidate = join(dir, 'node_modules/@opencode-ai/plugin/package.json')
+    try {
+      return readManifest(candidate)
+    } catch {
+      const parent = dirname(dir)
+      if (parent === dir) break
+      dir = parent
+    }
+  }
+  return null
+}
+
+/**
+ * Every DISTINCT installed copy of `name` reachable from the workspace.
+ *
+ * Two shapes have to be covered, because a duplicate can appear either way:
+ *
+ *   - the ancestor walk (`<pkg>/node_modules`, then each parent up to the
+ *     workspace root) — where a hoisted install lives;
+ *   - one nested level (`node_modules/<dep>/node_modules/<name>`, including
+ *     scoped `<scope>/<dep>`) — where npm parks a second copy when it cannot
+ *     satisfy every dependent with one hoisted version. That nested copy IS
+ *     the "ranges forced a second install" outcome, so a walk that only climbs
+ *     ancestors would pass while the tree carries two.
+ *
+ * Identity is the file's inode, not its path and not its realpath: Bun's store
+ * links one physical package into several trees, and it may use hardlinks,
+ * which `realpathSync` does not collapse. Two entries here therefore means two
+ * genuinely distinct installs on disk.
+ *
+ * Depth is bounded at one nested level. A duplicate buried deeper is not
+ * detected — that is a real limit, accepted because the failure this guards
+ * puts the second copy directly under the dependent that forced it.
+ */
+const findInstalledCopies = (name: string): string[] => {
+  const byInode = new Map<string, string>()
+
+  const record = (packageJson: string): void => {
+    if (!existsSync(packageJson)) return
+    const version = (
+      JSON.parse(readFileSync(packageJson, 'utf-8')) as { version?: string }
+    ).version
+    if (version === undefined) return
+    const stats = statSync(packageJson)
+    byInode.set(`${stats.dev}:${stats.ino}`, version)
+  }
+
+  const scanNested = (modulesDir: string): void => {
+    if (!existsSync(modulesDir)) return
+    for (const entry of readdirSync(modulesDir)) {
+      if (entry === '.bin' || entry === '.cache') continue
+      const owners = entry.startsWith('@')
+        ? readdirSync(join(modulesDir, entry)).map((child) =>
+            join(entry, child),
+          )
+        : [entry]
+      for (const owner of owners) {
+        record(join(modulesDir, owner, 'node_modules', name, 'package.json'))
+      }
+    }
+  }
+
+  let dir = PACKAGE_ROOT
+  for (let depth = 0; depth < 6; depth += 1) {
+    const modulesDir = join(dir, 'node_modules')
+    record(join(modulesDir, name, 'package.json'))
+    scanNested(modulesDir)
+    const parent = dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  return [...byInode.values()]
+}
+
+/** Stands in for "some future release the host will happily accept". */
+const FUTURE_VERSION = '999.0.0'
+
+describe('published dependency ranges', () => {
+  it('declares no upper bound on the host\u2019s own peer dependencies', () => {
+    const host = findHostManifest()
+    expect(host).not.toBeNull()
+
+    // Only the host's PEER dependencies matter here: npm requires a peer to be
+    // satisfied by ONE version shared with the dependent, so our range and the
+    // host's must be simultaneously satisfiable or the install aborts. The
+    // host's ordinary `dependencies` (e.g. zod) can nest a second copy, so a
+    // bound there is not an install hazard and is deliberately not flagged.
+    const hostPeers = Object.keys(host?.peerDependencies ?? {})
+
+    const shared = hostPeers.filter((name) => name in ourRanges)
+    // If this is ever empty the test has stopped testing anything.
+    expect(shared.length).toBeGreaterThan(0)
+
+    const capped = shared.filter(
+      (name) => !Bun.semver.satisfies(FUTURE_VERSION, ourRanges[name] ?? ''),
+    )
+    expect(capped).toEqual([])
+  })
+
+  it('declares no upper bound on the host plugin itself', () => {
+    const range = ourRanges['@opencode-ai/plugin']
+    expect(range).toBeDefined()
+    expect(Bun.semver.satisfies(FUTURE_VERSION, range ?? '')).toBe(true)
+  })
+
+  it('the installed tree resolves one shared copy per host peer', () => {
+    // The static assertions above cannot see an actual resolution, so pin the
+    // outcome they exist to protect: for every host peer we also declare, the
+    // workspace must contain exactly ONE installed copy, and its version must
+    // satisfy both ranges at once. This is the property npm enforces at
+    // install time and the one the 2.0.0 ranges made unsatisfiable.
+    const host = findHostManifest()
+    expect(host).not.toBeNull()
+    const hostPeers = host?.peerDependencies ?? {}
+
+    const shared = Object.keys(hostPeers).filter((name) => name in ourRanges)
+    expect(shared.length).toBeGreaterThan(0)
+
+    for (const name of shared) {
+      const copies = findInstalledCopies(name)
+      // Exactly one copy: a second means the ranges forced a duplicate
+      // install rather than one shared version every dependent can use.
+      expect({ name, copies: copies.length }).toEqual({ name, copies: 1 })
+
+      const installed = copies[0] ?? ''
+      expect({
+        name,
+        satisfiesOurs: Bun.semver.satisfies(installed, ourRanges[name] ?? ''),
+        satisfiesHost: Bun.semver.satisfies(installed, hostPeers[name] ?? ''),
+      }).toEqual({ name, satisfiesOurs: true, satisfiesHost: true })
+    }
+  })
+
+  it('accepts the OpenTUI versions the host accepts', () => {
+    // The concrete regression: 0.5.x was rejected by `^0.4.5`.
+    for (const name of ['@opentui/core', '@opentui/keymap', '@opentui/solid']) {
+      const range = ourRanges[name]
+      expect(range).toBeDefined()
+      for (const version of ['0.4.5', '0.5.0', '0.5.1', '1.0.0']) {
+        expect(Bun.semver.satisfies(version, range ?? '')).toBe(true)
+      }
+    }
+  })
+})


### PR DESCRIPTION
Installing 2.0.0 fails outright on a current host. Reported in Discord by two users; the trigger is anything that rebuilds the plugin cache (`rm -rf ~/.cache/opencode`, a fresh machine, a new install).

```
npm error ERESOLVE unable to resolve dependency tree
npm error Found: @opentui/core@0.5.1
npm error peer @opentui/core@"^0.4.5" from @cortexkit/opencode-antigravity-auth@2.0.0
```

The failure does not look like a failure. npm aborts, the plugin is never installed, and the user sees:

```
ProviderModelNotFoundError: Model not found: google/antigravity-claude-opus-4-6-thinking
```

## Cause

2.0.0 declared `@opentui/*` as peer dependencies at `^0.4.5`. On a `0.x` version, caret is minor-locked — `^0.4.5` means `>=0.4.5 <0.5.0`. OpenTUI has since released 0.5.0 and 0.5.1.

`@opencode-ai/plugin` declares the same three packages as **optional** peers at `>=0.4.5`, so the host resolves 0.5.1 happily. Our range rejects it, and no single version satisfies both — hence ERESOLVE.

This was a 2.0.0 regression. 1.1.0 declared neither the OpenTUI peers nor a host-version ceiling.

## Fix

Match the shape the sibling `openai-auth` plugin already uses:

```diff
   "peerDependencies": {
-    "@opencode-ai/plugin": "^1.17.13",
-    "@opentui/core": "^0.4.5",
-    "@opentui/keymap": "^0.4.5",
-    "@opentui/solid": "^0.4.5",
+    "@opencode-ai/plugin": "*",
     "typescript": "^5 || ^6"
   },
   "dependencies": {
+    "@opentui/core": ">=0.4.5",
+    "@opentui/keymap": ">=0.4.5",
+    "@opentui/solid": ">=0.4.5",
```

The `^1.17.13` ceiling on the host goes too. It is not biting yet — 1.18.11 satisfies it — but it is the same defect one major bump away, and both sibling plugins use `*`.

I also tested keeping the OpenTUI packages as peers marked `optional`. That installs cleanly but leaves them uninstalled, and the `./tui` entry then fails to import. Ordinary dependencies is the correct shape for a package that imports them at runtime.

`engines.opencode` still reads `>=1.17.13 <2`. Left alone deliberately: it is advisory rather than resolver input, so it does not cause this failure, and tightening or loosening it is a separate call.

## Verification

Installed the packed tarball against the exact host from the report:

```
$ npm i @opencode-ai/plugin@1.18.11 ./cortexkit-opencode-antigravity-auth-2.0.0.tgz
install exit=0   ERESOLVE lines=0

opentui/core : 0.5.1
opentui/solid: 0.5.1
host plugin  : 1.18.11
server entry : AntigravityCLIOAuthPlugin,GoogleOAuthPlugin
tui entry    : resolves (src/tui/entry.mjs + src/tui-compiled/tui.tsx present)
```

`npm ls` shows one hoisted copy — `@opentui/core@0.5.1` with keymap and solid both `deduped`, so no duplicate runtime.

Gates: 1830 unit / 0 fail · 28 e2e / 0 fail · typecheck · format · lint · `build` · `smoke:tui`.

## Regression guard

`packages/opencode/src/package-manifest.test.ts` fails when any range we publish for one of the host's own **peer** dependencies rejects a future version, since those must resolve to a single shared copy. It reads the host manifest from the installed tree rather than hardcoding a version, and asserts directly that 0.4.5 / 0.5.0 / 0.5.1 / 1.0.0 are all accepted.

Restoring the 2.0.0 ranges turns all three tests red:

```
(fail) declares no upper bound on the host's own peer dependencies
(fail) declares no upper bound on the host plugin itself
(fail) accepts the OpenTUI versions the host accepts
0 pass, 3 fail
```

The host's ordinary `dependencies` are deliberately not flagged — those can nest a second copy, so a bound there is not an install hazard. Scoping to peers only was a correction: the first version of the guard flagged `zod` and would have been wrong.

## For affected users before a release

```bash
npm i --legacy-peer-deps
```

or `legacy-peer-deps=true` in `.npmrc`. Both verified — the plugin installs and the server entry loads.

This needs a patch release to reach anyone; the fix has no effect until 2.0.1 is on npm.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/antigravity-auth/pr/12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788475112&installation_model_id=22398&pr_number=12&repository=cortexkit%2Fantigravity-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fantigravity-auth%2Fpull%2F12&signature=4d5de00f92a2b2c8711c54da305e186b8be1d42ef0168fd65ffcc186a0ce046d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix npm install failures on fresh hosts by removing upper bounds on shared OpenTUI packages and making them direct dependencies. Adds a guard test to block future ceilings and duplicated installs so one version is shared with the host.

- **Bug Fixes**
  - Moved `@opentui/core`, `@opentui/keymap`, `@opentui/solid` from peerDeps `^0.4.5` to deps `>=0.4.5` to allow 0.5.x+ and match the host.
  - Relaxed `@opencode-ai/plugin` peer range to `*`.
  - Added `package-manifest.test.ts` to fail on any ceilings, assert OpenTUI `0.4.5/0.5.x/1.x` are accepted, and verify exactly one installed copy across ancestor and nested trees (hardlinks handled).

<sup>Written for commit a4761e7e7ce8c79230344eb2b8bdc0f2fb81c220. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/antigravity-auth/pull/12?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

