### PR TITLE
feat(opencode-v2): OpenCode 2.x host adapter (reuses the existing core)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,8 @@ jobs:
             workspace: "@cortexkit/opencode-antigravity-auth"
           - package: "@cortexkit/pi-antigravity-auth"
             workspace: "@cortexkit/pi-antigravity-auth"
+          - package: "@cortexkit/opencode-v2-antigravity-auth"
+            workspace: "@cortexkit/opencode-v2-antigravity-auth"
     steps:
       - uses: actions/checkout@v5
         with:

--- a/README.md
+++ b/README.md
@@ -405,14 +405,14 @@ The script enforces semver, refuses to run on a dirty tree, and refuses to run o
 The `Release` workflow (`.github/workflows/release.yml`) runs on tag push (or `workflow_dispatch`) and:
 
 1. **Test** job — checkout the tag ref → install Bun 1.3 + Node 24 → `bun install --frozen-lockfile` → `bun run typecheck` → `bun run build` → `bun run --cwd packages/opencode smoke:tui` → `bun test` → `bun run test:e2e` → `bun run format:check` → `bun run lint`.
-2. **Publish** job — matrixed across the three packages (`@cortexkit/antigravity-auth-core`, `@cortexkit/opencode-antigravity-auth`, `@cortexkit/pi-antigravity-auth`) with `max-parallel: 1` so each package picks up its own OIDC token; `npm Trusted Publishing` (`npm publish --workspace … --access public --provenance`) handles the upload. The job skips a package if its npm version is already published.
+2. **Publish** job — matrixed across the four packages (`@cortexkit/antigravity-auth-core`, `@cortexkit/opencode-antigravity-auth`, `@cortexkit/pi-antigravity-auth`, `@cortexkit/opencode-v2-antigravity-auth`) with `max-parallel: 1` so each package picks up its own OIDC token; `npm Trusted Publishing` (`npm publish --workspace … --access public --provenance`) handles the upload. The job skips a package if its npm version is already published.
 3. **GitHub Release** job — `softprops/action-gh-release@v2` creates the GitHub release with `generate_release_notes: true`.
 
 CI (`.github/workflows/ci.yml`) reuses the same typecheck → build → smoke → test → e2e → format → lint chain on every push to `main` and on every pull request. The `issue-triage.yml` workflow handles GitHub-issue routing.
 
 ## Architecture and structure links
 
-- [ARCHITECTURE.md](ARCHITECTURE.md) — system-of-record architecture doc across all three packages.
+- [ARCHITECTURE.md](ARCHITECTURE.md) — system-of-record architecture doc across all four packages.
 - [STRUCTURE.md](STRUCTURE.md) — file-system map of the monorepo.
 - [packages/opencode/ARCHITECTURE.md](packages/opencode/ARCHITECTURE.md) — OpenCode plugin architecture in detail.
 - [packages/opencode/STRUCTURE.md](packages/opencode/STRUCTURE.md) — OpenCode package file-system map.

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 Google Antigravity OAuth for coding agents. Authenticate with your Google account and access Antigravity quota for Gemini, Claude, and GPT-OSS models from OpenCode, the Pi coding agent, or the standalone CLI.
 
-This monorepo ships three packages:
+This monorepo ships four packages:
 
 | Package | Host | Role |
 | --- | --- | --- |
 | [`@cortexkit/opencode-antigravity-auth`](packages/opencode) | OpenCode 1.x server | Intercepts `fetch()`, runs the account pool + quota manager, drives slash commands, and exposes a TUI sidebar through a loopback RPC. |
 | [`@cortexkit/pi-antigravity-auth`](packages/pi) | Pi coding agent | Registers a custom provider with OAuth login + Gemini streaming. |
+| [`@cortexkit/opencode-v2-antigravity-auth`](packages/opencode-v2) | OpenCode 2.x server | Registers the Antigravity models through the native plugin API: a loopback bridge for the account pool and transport, an OAuth method that appends accounts, and a document tool for PDF input. |
 | [`@cortexkit/antigravity-auth-core`](packages/core) | Any harness | Harness-agnostic core: OAuth PKCE, raw HTTP/1.1 transport, device fingerprint, request transforms, account pool, quota manager, durable storage. Both host packages depend on it. |
 
 ## Risk and terms-of-service warning

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -24,6 +24,7 @@
       "packages/*/scripts/**",
       "scripts/**",
       "test/**",
+      "packages/*/test/**",
       "*.json",
       "packages/*/*.json",
       ".github/**/*.yml"

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "packages/core": {
       "name": "@cortexkit/antigravity-auth-core",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "@openauthjs/openauth": "^0.4.3",
         "xdg-basedir": "^5.1.0",
@@ -41,7 +41,7 @@
     },
     "packages/opencode": {
       "name": "@cortexkit/opencode-antigravity-auth",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "bin": {
         "antigravity-auth": "./dist/cli.js",
       },
@@ -66,9 +66,16 @@
         "typescript": "^5 || ^6",
       },
     },
+    "packages/opencode-v2": {
+      "name": "@cortexkit/opencode-v2-antigravity-auth",
+      "version": "2.1.0",
+      "dependencies": {
+        "@cortexkit/antigravity-auth-core": "2.1.0",
+      },
+    },
     "packages/pi": {
       "name": "@cortexkit/pi-antigravity-auth",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "@cortexkit/antigravity-auth-core": "2.0.0",
       },
@@ -221,6 +228,8 @@
     "@cortexkit/antigravity-auth-e2e": ["@cortexkit/antigravity-auth-e2e@workspace:packages/e2e-tests"],
 
     "@cortexkit/opencode-antigravity-auth": ["@cortexkit/opencode-antigravity-auth@workspace:packages/opencode"],
+
+    "@cortexkit/opencode-v2-antigravity-auth": ["@cortexkit/opencode-v2-antigravity-auth@workspace:packages/opencode-v2"],
 
     "@cortexkit/pi-antigravity-auth": ["@cortexkit/pi-antigravity-auth@workspace:packages/pi"],
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   ],
   "scripts": {
     "build": "bun run --cwd packages/core build && bun run --cwd packages/opencode build && bun run --cwd packages/pi build",
-    "typecheck": "bun run --cwd packages/core build && bun run --cwd packages/opencode typecheck && bun run --cwd packages/pi typecheck && tsc -p tsconfig.scripts.json",
-    "test": "bun run --cwd packages/core build && bun test --isolate packages/core/src packages/opencode/src packages/pi/src test/",
+    "typecheck": "bun run --cwd packages/core build && bun run --cwd packages/opencode typecheck && bun run --cwd packages/pi typecheck && tsc -p tsconfig.scripts.json && node --check packages/opencode-v2/src/plugin.mjs packages/opencode-v2/src/oauth-callback.mjs",
+    "test": "bun run --cwd packages/core build && bun test --isolate packages/core/src packages/opencode/src packages/pi/src test/ packages/opencode-v2/test/",
     "test:e2e": "bun test --isolate ./packages/e2e-tests/src/plugin-flow.e2e.test.ts ./packages/e2e-tests/src/cli-flow.e2e.test.ts ./packages/e2e-tests/src/rpc-tui-flow.e2e.test.ts ./packages/e2e-tests/src/fetch-guard.test.ts ./packages/e2e-tests/src/mock-antigravity-server.test.ts",
     "test:e2e:models": "bun run --cwd packages/opencode test:e2e:models",
     "test:e2e:regression": "bun run --cwd packages/opencode test:e2e:regression",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "scripts": {
     "build": "bun run --cwd packages/core build && bun run --cwd packages/opencode build && bun run --cwd packages/pi build",
-    "typecheck": "bun run --cwd packages/core build && bun run --cwd packages/opencode typecheck && bun run --cwd packages/pi typecheck && tsc -p tsconfig.scripts.json && node --check packages/opencode-v2/src/plugin.mjs packages/opencode-v2/src/oauth-callback.mjs",
+    "typecheck": "bun run --cwd packages/core build && bun run --cwd packages/opencode typecheck && bun run --cwd packages/pi typecheck && tsc -p tsconfig.scripts.json && node --check packages/opencode-v2/src/plugin.mjs && node --check packages/opencode-v2/src/oauth-callback.mjs",
     "test": "bun run --cwd packages/core build && bun test --isolate packages/core/src packages/opencode/src packages/pi/src test/ packages/opencode-v2/test/",
     "test:e2e": "bun test --isolate ./packages/e2e-tests/src/plugin-flow.e2e.test.ts ./packages/e2e-tests/src/cli-flow.e2e.test.ts ./packages/e2e-tests/src/rpc-tui-flow.e2e.test.ts ./packages/e2e-tests/src/fetch-guard.test.ts ./packages/e2e-tests/src/mock-antigravity-server.test.ts",
     "test:e2e:models": "bun run --cwd packages/opencode test:e2e:models",

--- a/packages/opencode-v2/LICENSE
+++ b/packages/opencode-v2/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/opencode-v2/README.md
+++ b/packages/opencode-v2/README.md
@@ -1,0 +1,144 @@
+# opencode-v2-antigravity
+
+Google Antigravity provider for **OpenCode 2.x**, built on
+[`@cortexkit/antigravity-auth-core`](https://www.npmjs.com/package/@cortexkit/antigravity-auth-core).
+
+`@cortexkit/opencode-antigravity-auth` targets the OpenCode 1.x host
+(`engines.opencode: ">=1.17.13 <2"`): it patches `fetch()` and registers a TUI sidebar.
+OpenCode 2.x replaced that surface with a typed plugin API (`session.hook`,
+`integration.transform`, `tool.transform`, native provider packages), so the 1.x plugin cannot
+load there. This package is that missing host adapter — OAuth, transport, account pool, quota
+bookkeeping and the model registry all stay in the shared core.
+
+> **Terms-of-service warning.** This calls Antigravity's non-public internal API. It is not
+> endorsed by Google and may violate Google's Terms of Service; accounts have reportedly been
+> suspended for similar use. Use at your own risk and never with an important account.
+
+## Design
+
+```
+OpenCode 2.x                          this plugin                    Antigravity
+────────────                          ───────────                    ───────────
+native @opencode-ai/ai/providers/google
+  builds Gemini request  ──▶  session.hook("http.request")
+                                rewrites the URL to a 127.0.0.1 loopback
+                                       │
+                                       ▼
+                             loopback HTTP server
+                                · picks an account (hybrid strategy)
+                                · refreshes the OAuth token
+                                · ensureProjectContext()
+                                · agent envelope + labels/sessionId
+                                · fetchWithAgyCliTransport()  ──▶  daily-cloudcode-pa
+                                                                    (fallback cloudcode-pa)
+                                       │
+  parses Gemini SSE      ◀───────  unwrapped, schema-normalised SSE
+```
+
+Keeping the native `@opencode-ai/ai/providers/google` package as the codec means image, PDF and
+tool-call handling comes from the host instead of a hand-written adapter.
+
+Why a loopback server instead of returning a `Response` from the hook: OpenCode 2.x sends
+whatever `event.request` the hook leaves behind through its own HTTP client, and the
+`http.response` hook only runs after that request succeeded. A loopback endpoint keeps the
+core's raw HTTP/1.1 transport (agy header order, proxy support) while the host still sees a
+plain SSE response it can stream and cancel.
+
+## Install
+
+```bash
+npm install @cortexkit/antigravity-auth-core
+```
+
+Register the plugin and the models in `opencode.json` (full snippet in
+[`example/opencode.json`](example/opencode.json)):
+
+```jsonc
+{
+  "plugins": [{ "package": "/absolute/path/to/opencode-v2-antigravity/src/plugin.mjs" }],
+  "providers": {
+    "google": {
+      "models": {
+        "gemini-3.7-flash": {
+          "name": "Gemini 3.7 Flash",
+          "modelID": "gemini-3.7-flash",
+          "package": "@opencode-ai/ai/providers/google",
+          "capabilities": { "tools": true, "input": ["text", "image", "pdf"], "output": ["text"] },
+          "limit": { "context": 1048576, "output": 65536 },
+          "variants": [{ "id": "low" }, { "id": "medium" }, { "id": "high" }]
+        }
+      }
+    }
+  }
+}
+```
+
+## Accounts
+
+- Pool file: `antigravity-accounts.json` in the OpenCode config dir
+  (`$OPENCODE_CONFIG_DIR`, `$XDG_CONFIG_HOME/opencode`, `%APPDATA%\opencode`, or
+  `~/.config/opencode`); override with `ANTIGRAVITY_ACCOUNTS_FILE`. Storage schema v4 with the
+  core's fenced file lock, so the pool is shared with the 1.x plugin and the standalone CLI.
+- Add an account: connect the `google` integration and pick
+  **"Google Antigravity (add account)"**. Each login appends to the pool; existing accounts are
+  preserved. The callback listens on `127.0.0.1:51121/oauth-callback`.
+- Disable an account with `"enabled": false`.
+- Selection uses the core `hybrid` strategy. On `429`/`403` the account is cooled down and the
+  next one is tried, `401` forces a token refresh, and a bare `STOP` (empty candidates) is
+  retried up to three times.
+
+## Models
+
+| Selector | Variants | Wire model |
+| --- | --- | --- |
+| `google/gemini-3.7-flash` | low, medium, high | `gemini-3.7-flash-{tier}` |
+| `google/gemini-3.6-flash` | low, medium, high | `gemini-3.6-flash-{tier}` |
+| `google/gemini-3.5-flash` | low, medium, high | `gemini-3.5-flash-extra-low` / `gemini-3.5-flash-low` / `gemini-3-flash-agent` |
+| `google/gemini-3.1-pro` | low, high | `gemini-3.1-pro-low` / `gemini-pro-agent` |
+| `google/gemini-3.1-flash-image` | — | `gemini-3.1-flash-image` |
+| `google/claude-sonnet-4-6-thinking` | — | `claude-sonnet-4-6` |
+| `google/claude-opus-4-6-thinking` | — | `claude-opus-4-6-thinking` |
+| `google/gpt-oss-120b-medium` | — | `gpt-oss-120b-medium` |
+
+Model ids and tiers come from `resolveModelForHeaderStyle()`, so the registry stays the single
+source of truth.
+
+## Host quirks this plugin works around
+
+1. **GPT-OSS tool schemas** — the AGY GPT bridge re-encodes protobuf numeric constraints as
+   strings, so `minLength: 1` fails OpenAI JSON-Schema validation with `400 INVALID_ARGUMENT`.
+   Fixed by calling `normalizeGeminiTools(request, { moveNumericConstraintsToDescription: true })`
+   for `gpt-*` wire models.
+2. **Strict native event schema** — GPT-OSS opens a turn with `content` and no `parts`, and
+   Claude sometimes uses role `assistant`. Both are rejected by the native Gemini event schema
+   (`Invalid google/gemini stream event`), so every frame is normalised before being forwarded.
+3. **Response encoding** — the core transport already inflates gzip, so upstream
+   `content-encoding` headers must not be copied onto the loopback response.
+4. **PDF attachments** — the OpenCode 2.x CLI drops PDF attachments before the provider sees
+   them (the request arrives without any `inlineData`). The plugin therefore also registers an
+   `antigravity_read_document` tool that loads the file itself:
+   `antigravity_read_document({ path, question?, model? })` for `.pdf`, `.png`, `.jpg`, `.webp`,
+   `.gif`, `.heic`. Images attached in chat work without the tool.
+5. **Image output** — the native parser renders text and tool calls only, so generated images
+   are written to `<data dir>/antigravity-images/` and announced as text.
+
+## Logging and privacy
+
+`<state dir>/antigravity-v2.log` records routing, `#<account index>`, upstream status codes,
+rotation and saved image paths. No prompts, tokens, e-mail addresses or refresh tokens are
+written. Credentials live only in the pool file owned by the core.
+
+## Verified
+
+Windows 11, Node 24, OpenCode `0.0.0-beta-17595`, two-account pool:
+
+- all eight selectors above answered a live prompt, including every reasoning tier;
+- tool calling works end to end (the model called `read` and returned a directory listing);
+- PNG attachment recognised (a red square → "Red");
+- PDF read through `antigravity_read_document` (exact embedded string returned);
+- image generation produced two JPEG files on disk;
+- forced failover: disabling account `#0` routed the next request to account `#1`.
+
+## License
+
+MIT.

--- a/packages/opencode-v2/README.md
+++ b/packages/opencode-v2/README.md
@@ -46,16 +46,38 @@ plain SSE response it can stream and cancel.
 
 ## Install
 
+Install the adapter package itself (the shared core is pulled in automatically):
+
 ```bash
-npm install @cortexkit/antigravity-auth-core
+# once the package is published:
+npm install @cortexkit/opencode-v2-antigravity-auth
+# or from this repository (Bun workspace):
+bun install
 ```
+
+The plugin entry is `src/plugin.mjs` inside the package. In `opencode.json`, point
+`plugins[].package` at that file — for an npm install use
+`node_modules/@cortexkit/opencode-v2-antigravity-auth/src/plugin.mjs` relative to the project,
+for a checkout use the absolute path
+`/path/to/antigravity-auth/packages/opencode-v2/src/plugin.mjs`. The example below uses a
+checkout path.
 
 Register the plugin and the models in `opencode.json` (full snippet in
 [`example/opencode.json`](example/opencode.json)):
 
 ```jsonc
 {
-  "plugins": [{ "package": "/absolute/path/to/opencode-v2-antigravity/src/plugin.mjs" }],
+  "plugins": [
+    {
+      "package": "/absolute/path/to/antigravity-auth/packages/opencode-v2/src/plugin.mjs",
+      "options": {
+        // Optional: restrict which directories antigravity_read_document may read.
+        // Default: anything under the user's home directory (credential/secret
+        // paths are always blocked).
+        "readDocumentRoots": ["/absolute/path/to/project/docs"]
+      }
+    }
+  ],
   "providers": {
     "google": {
       "models": {
@@ -119,6 +141,14 @@ source of truth.
    `antigravity_read_document` tool that loads the file itself:
    `antigravity_read_document({ path, question?, model? })` for `.pdf`, `.png`, `.jpg`, `.webp`,
    `.gif`, `.heic`. Images attached in chat work without the tool.
+   **Security note:** the tool reads local files and sends them to the Antigravity server —
+   an untrusted PDF/image is a prompt-injection vector that could instruct the model to read
+   sensitive files. Paths are therefore checked: well-known credential/secret locations
+   (`~/.ssh`, `~/.config`, `~/.local`, `AppData`, `.env`, `*.key`, `*.pem`, `*.p12`, `*.pfx`,
+   `id_rsa`, `credentials`, `auth.json`, `antigravity-accounts.json`, …) are always refused,
+   and by default only files under the user's home directory are readable. To narrow the
+   readable root further, set the `readDocumentRoots` plugin option (array of absolute
+   directories). Prefer attaching documents in chat where the host preserves them.
 5. **Image output** — the native parser renders text and tool calls only, so generated images
    are written to `<data dir>/antigravity-images/` and announced as text.
 

--- a/packages/opencode-v2/README.zh-CN.md
+++ b/packages/opencode-v2/README.zh-CN.md
@@ -44,15 +44,32 @@ OpenCode 2.x                          本插件                        Antigravi
 ## 安装
 
 ```bash
-npm install @cortexkit/antigravity-auth-core
+# 包发布后：
+npm install @cortexkit/opencode-v2-antigravity-auth
+# 或从本仓库（Bun workspace）：
+bun install
 ```
+
+插件的入口是包内的 `src/plugin.mjs`。在 `opencode.json` 中，把 `plugins[].package` 指向该文件：
+npm 安装时用 `node_modules/@cortexkit/opencode-v2-antigravity-auth/src/plugin.mjs`
+（相对于项目目录），从仓库检出时用绝对路径
+`/path/to/antigravity-auth/packages/opencode-v2/src/plugin.mjs`。下面示例使用检出路径。
 
 然后在 `opencode.json` 中注册插件与模型（完整示例见
 [`example/opencode.json`](example/opencode.json)）：
 
 ```jsonc
 {
-  "plugins": [{ "package": "/绝对路径/opencode-v2-antigravity/src/plugin.mjs" }],
+  "plugins": [
+    {
+      "package": "/绝对路径/antigravity-auth/packages/opencode-v2/src/plugin.mjs",
+      "options": {
+        // 可选：限定 antigravity_read_document 可读取的目录。
+        // 默认：用户主目录下的任意位置（凭据/密钥路径始终被拦截）。
+        "readDocumentRoots": ["/绝对路径/project/docs"]
+      }
+    }
+  ],
   "providers": {
     "google": {
       "models": {
@@ -113,6 +130,13 @@ npm install @cortexkit/antigravity-auth-core
    （请求中没有任何 `inlineData`）。因此插件额外注册了 `antigravity_read_document` 工具，
    由插件自己读取文件：`antigravity_read_document({ path, question?, model? })`，
    支持 `.pdf`、`.png`、`.jpg`、`.webp`、`.gif`、`.heic`。聊天中粘贴的图片无需该工具即可工作。
+   **安全说明**：该工具会读取本地文件并发送到 Antigravity 服务器 —— 不可信的 PDF/图片是
+   prompt-injection 的载体，可能诱导模型读取敏感文件。因此路径经过检查：
+   常见的凭据/密钥位置（`~/.ssh`、`~/.config`、`~/.local`、`AppData`、`.env`、`*.key`、
+   `*.pem`、`*.p12`、`*.pfx`、`id_rsa`、`credentials`、`auth.json`、
+   `antigravity-accounts.json` 等）始终被拒绝；默认只允许读取用户主目录下的文件。如需
+   进一步收窄可读范围，请设置插件选项 `readDocumentRoots`（绝对路径数组）。尽量在聊天中
+   附带文档，宿主会保留附件。
 5. **图片输出**：原生解析器只渲染文本与 tool call，因此生成的图片会写入
    `<data dir>/antigravity-images/`，并以文本形式告知路径。
 

--- a/packages/opencode-v2/README.zh-CN.md
+++ b/packages/opencode-v2/README.zh-CN.md
@@ -1,0 +1,137 @@
+# opencode-v2-antigravity
+
+面向 **OpenCode 2.x** 的 Google Antigravity provider，基于
+[`@cortexkit/antigravity-auth-core`](https://www.npmjs.com/package/@cortexkit/antigravity-auth-core) 实现。
+
+`@cortexkit/opencode-antigravity-auth` 面向 OpenCode 1.x 宿主
+（`engines.opencode: ">=1.17.13 <2"`）：它通过劫持 `fetch()` 并注册 TUI 侧边栏来工作。
+OpenCode 2.x 用新的插件 API 取代了这些接口（`session.hook`、`integration.transform`、
+`tool.transform`、原生 provider 包），因此 1.x 插件无法在 2.x 中加载。本包补上了这层宿主适配：
+OAuth、传输、账号池、配额与模型注册表仍然全部复用共享 core。
+
+> **服务条款警告。** 本项目调用 Antigravity 的非公开内部 API，未获 Google 认可，可能违反
+> Google 服务条款；已有账号因类似用法被限制的报告。请自行评估风险，不要使用重要账号。
+
+## 设计
+
+```
+OpenCode 2.x                          本插件                        Antigravity
+────────────                          ──────                        ───────────
+原生 @opencode-ai/ai/providers/google
+  构造 Gemini 请求      ──▶  session.hook("http.request")
+                                将 URL 改写为 127.0.0.1 回环地址
+                                       │
+                                       ▼
+                             回环 HTTP 服务
+                                · 选择账号（hybrid 策略）
+                                · 刷新 OAuth token
+                                · ensureProjectContext()
+                                · agent 信封 + labels/sessionId
+                                · fetchWithAgyCliTransport()  ──▶  daily-cloudcode-pa
+                                                                    （回退 cloudcode-pa）
+                                       │
+  解析 Gemini SSE       ◀───────  解包并规范化后的 SSE
+```
+
+保留原生 `@opencode-ai/ai/providers/google` 作为编解码器，意味着图片、PDF 和 tool call
+都交由宿主处理，不需要手写 adapter。
+
+为什么使用回环服务，而不是在 hook 里直接返回 `Response`：OpenCode 2.x 会把 hook 留下的
+`event.request` 交给自己的 HTTP 客户端发送，而 `http.response` hook 只在该请求成功之后才会执行。
+回环端点既保留了 core 的原始 HTTP/1.1 传输（agy 的 header 顺序、代理支持），又让宿主看到一个
+可以正常流式读取与取消的 SSE 响应。
+
+## 安装
+
+```bash
+npm install @cortexkit/antigravity-auth-core
+```
+
+然后在 `opencode.json` 中注册插件与模型（完整示例见
+[`example/opencode.json`](example/opencode.json)）：
+
+```jsonc
+{
+  "plugins": [{ "package": "/绝对路径/opencode-v2-antigravity/src/plugin.mjs" }],
+  "providers": {
+    "google": {
+      "models": {
+        "gemini-3.7-flash": {
+          "name": "Gemini 3.7 Flash",
+          "modelID": "gemini-3.7-flash",
+          "package": "@opencode-ai/ai/providers/google",
+          "capabilities": { "tools": true, "input": ["text", "image", "pdf"], "output": ["text"] },
+          "limit": { "context": 1048576, "output": 65536 },
+          "variants": [{ "id": "low" }, { "id": "medium" }, { "id": "high" }]
+        }
+      }
+    }
+  }
+}
+```
+
+## 账号
+
+- 账号池文件：OpenCode 配置目录下的 `antigravity-accounts.json`
+  （`$OPENCODE_CONFIG_DIR`、`$XDG_CONFIG_HOME/opencode`、`%APPDATA%\opencode`
+  或 `~/.config/opencode`），可用 `ANTIGRAVITY_ACCOUNTS_FILE` 覆盖。
+  存储结构为 v4，并使用 core 的文件锁，因此与 1.x 插件、独立 CLI 共享同一份数据。
+- 添加账号：连接 `google` integration，选择
+  **“Google Antigravity (add account)”**。每次登录都是**追加**，不会覆盖已有账号。
+  回调监听 `127.0.0.1:51121/oauth-callback`。
+- 停用账号：把该条目设为 `"enabled": false`。
+- 账号选择使用 core 的 `hybrid` 策略；遇到 `429`/`403` 会让该账号冷却并切换到下一个，
+  `401` 会强制刷新 token，返回空候选的 `STOP` 最多重试三次。
+
+## 模型
+
+| 选择器 | 变体 | 实际下发模型 |
+| --- | --- | --- |
+| `google/gemini-3.7-flash` | low, medium, high | `gemini-3.7-flash-{tier}` |
+| `google/gemini-3.6-flash` | low, medium, high | `gemini-3.6-flash-{tier}` |
+| `google/gemini-3.5-flash` | low, medium, high | `gemini-3.5-flash-extra-low` / `gemini-3.5-flash-low` / `gemini-3-flash-agent` |
+| `google/gemini-3.1-pro` | low, high | `gemini-3.1-pro-low` / `gemini-pro-agent` |
+| `google/gemini-3.1-flash-image` | — | `gemini-3.1-flash-image` |
+| `google/claude-sonnet-4-6-thinking` | — | `claude-sonnet-4-6` |
+| `google/claude-opus-4-6-thinking` | — | `claude-opus-4-6-thinking` |
+| `google/gpt-oss-120b-medium` | — | `gpt-oss-120b-medium` |
+
+模型 id 与推理档位来自 `resolveModelForHeaderStyle()`，注册表仍是唯一事实来源。
+
+## 已绕过的宿主/上游问题
+
+1. **GPT-OSS 的工具 schema**：AGY 的 GPT 桥接会把 protobuf 数值约束重新编码为字符串，
+   于是 `minLength: 1` 在 OpenAI JSON-Schema 校验中失败，返回 `400 INVALID_ARGUMENT`。
+   对 `gpt-*` 下发模型调用
+   `normalizeGeminiTools(request, { moveNumericConstraintsToDescription: true })` 即可解决。
+2. **原生事件 schema 很严格**：GPT-OSS 的首帧只有 `content` 而没有 `parts`，Claude 有时使用
+   `assistant` 角色，两者都会触发 `Invalid google/gemini stream event`。
+   因此每一帧在转发前都会被规范化。
+3. **响应编码**：core 传输层已经解压 gzip，因此上游的 `content-encoding` 头不能复制到
+   回环响应上。
+4. **PDF 附件**：OpenCode 2.x CLI 在请求到达 provider 之前就丢弃了 PDF 附件
+   （请求中没有任何 `inlineData`）。因此插件额外注册了 `antigravity_read_document` 工具，
+   由插件自己读取文件：`antigravity_read_document({ path, question?, model? })`，
+   支持 `.pdf`、`.png`、`.jpg`、`.webp`、`.gif`、`.heic`。聊天中粘贴的图片无需该工具即可工作。
+5. **图片输出**：原生解析器只渲染文本与 tool call，因此生成的图片会写入
+   `<data dir>/antigravity-images/`，并以文本形式告知路径。
+
+## 日志与隐私
+
+`<state dir>/antigravity-v2.log` 只记录路由、`#<账号序号>`、上游状态码、账号轮换与已保存图片路径；
+不写入任何 prompt、token、邮箱或 refresh token。凭据只保存在由 core 管理的账号池文件中。
+
+## 实测
+
+Windows 11、Node 24、OpenCode `0.0.0-beta-17595`、两账号池：
+
+- 上表 8 个选择器全部通过真实请求（包含每个推理档位）；
+- tool call 端到端可用（模型调用 `read` 并返回目录列表）；
+- PNG 附件识别正确（纯红色方块 → “Red”）；
+- 通过 `antigravity_read_document` 读取 PDF，返回了其中的精确文本；
+- 图片生成得到两个 JPEG 文件；
+- 强制故障转移：停用 `#0` 账号后，下一次请求走到了 `#1` 账号。
+
+## 许可证
+
+MIT。

--- a/packages/opencode-v2/example/opencode.json
+++ b/packages/opencode-v2/example/opencode.json
@@ -1,6 +1,11 @@
 {
   "plugins": [
-    { "package": "/absolute/path/to/opencode-v2-antigravity/src/plugin.mjs" }
+    {
+      "package": "/absolute/path/to/antigravity-auth/packages/opencode-v2/src/plugin.mjs",
+      "options": {
+        "readDocumentRoots": ["/absolute/path/to/documents"]
+      }
+    }
   ],
   "providers": {
     "google": {

--- a/packages/opencode-v2/example/opencode.json
+++ b/packages/opencode-v2/example/opencode.json
@@ -1,0 +1,71 @@
+{
+  "plugins": [
+    { "package": "/absolute/path/to/opencode-v2-antigravity/src/plugin.mjs" }
+  ],
+  "providers": {
+    "google": {
+      "models": {
+        "gemini-3.7-flash": {
+          "name": "Gemini 3.7 Flash",
+          "modelID": "gemini-3.7-flash",
+          "package": "@opencode-ai/ai/providers/google",
+          "capabilities": { "tools": true, "input": ["text", "image", "pdf"], "output": ["text"] },
+          "limit": { "context": 1048576, "output": 65536 },
+          "variants": [{ "id": "low" }, { "id": "medium" }, { "id": "high" }]
+        },
+        "gemini-3.6-flash": {
+          "name": "Gemini 3.6 Flash",
+          "modelID": "gemini-3.6-flash",
+          "package": "@opencode-ai/ai/providers/google",
+          "capabilities": { "tools": true, "input": ["text", "image", "pdf"], "output": ["text"] },
+          "limit": { "context": 1048576, "output": 65536 },
+          "variants": [{ "id": "low" }, { "id": "medium" }, { "id": "high" }]
+        },
+        "gemini-3.5-flash": {
+          "name": "Gemini 3.5 Flash",
+          "modelID": "gemini-3.5-flash",
+          "package": "@opencode-ai/ai/providers/google",
+          "capabilities": { "tools": true, "input": ["text", "image", "pdf"], "output": ["text"] },
+          "limit": { "context": 1048576, "output": 65536 },
+          "variants": [{ "id": "low" }, { "id": "medium" }, { "id": "high" }]
+        },
+        "gemini-3.1-pro": {
+          "name": "Gemini 3.1 Pro",
+          "modelID": "gemini-3.1-pro",
+          "package": "@opencode-ai/ai/providers/google",
+          "capabilities": { "tools": true, "input": ["text", "image", "pdf"], "output": ["text"] },
+          "limit": { "context": 1048576, "output": 65535 },
+          "variants": [{ "id": "low" }, { "id": "high" }]
+        },
+        "gemini-3.1-flash-image": {
+          "name": "Gemini 3.1 Flash Image",
+          "modelID": "gemini-3.1-flash-image",
+          "package": "@opencode-ai/ai/providers/google",
+          "capabilities": { "tools": true, "input": ["text", "image"], "output": ["text", "image"] },
+          "limit": { "context": 66000, "output": 33000 }
+        },
+        "claude-sonnet-4-6-thinking": {
+          "name": "Claude Sonnet 4.6 (Thinking)",
+          "modelID": "claude-sonnet-4-6-thinking",
+          "package": "@opencode-ai/ai/providers/google",
+          "capabilities": { "tools": true, "input": ["text", "image", "pdf"], "output": ["text"] },
+          "limit": { "context": 250000, "output": 64000 }
+        },
+        "claude-opus-4-6-thinking": {
+          "name": "Claude Opus 4.6 (Thinking)",
+          "modelID": "claude-opus-4-6-thinking",
+          "package": "@opencode-ai/ai/providers/google",
+          "capabilities": { "tools": true, "input": ["text", "image", "pdf"], "output": ["text"] },
+          "limit": { "context": 250000, "output": 64000 }
+        },
+        "gpt-oss-120b-medium": {
+          "name": "GPT-OSS 120B",
+          "modelID": "gpt-oss-120b-medium",
+          "package": "@opencode-ai/ai/providers/google",
+          "capabilities": { "tools": true, "input": ["text", "image", "pdf"], "output": ["text"] },
+          "limit": { "context": 131072, "output": 32768 }
+        }
+      }
+    }
+  }
+}

--- a/packages/opencode-v2/package.json
+++ b/packages/opencode-v2/package.json
@@ -42,8 +42,8 @@
   "scripts": {
     "lint": "biome lint src example",
     "format:check": "biome format src example README.md README.zh-CN.md",
-    "typecheck": "node --check src/plugin.mjs src/oauth-callback.mjs",
-    "test": "bun run --cwd ../core build && bun test test"
+    "typecheck": "node --check src/plugin.mjs && node --check src/oauth-callback.mjs",
+    "test": "bun run --cwd ../core build && cd ../.. && bun test --isolate packages/opencode-v2/test"
   },
   "dependencies": {
     "@cortexkit/antigravity-auth-core": "2.1.0"

--- a/packages/opencode-v2/package.json
+++ b/packages/opencode-v2/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@cortexkit/opencode-v2-antigravity-auth",
+  "version": "2.1.0",
+  "description": "Google Antigravity provider for OpenCode 2.x (native plugin API)",
+  "type": "module",
+  "license": "MIT",
+  "author": "CortexKit",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cortexkit/antigravity-auth.git",
+    "directory": "packages/opencode-v2"
+  },
+  "homepage": "https://github.com/cortexkit/antigravity-auth#readme",
+  "bugs": {
+    "url": "https://github.com/cortexkit/antigravity-auth/issues"
+  },
+  "keywords": [
+    "opencode",
+    "opencode-v2",
+    "antigravity",
+    "gemini",
+    "claude",
+    "oauth",
+    "plugin"
+  ],
+  "engines": {
+    "node": ">=20.0.0",
+    "opencode": ">=2 <3"
+  },
+  "main": "./src/plugin.mjs",
+  "exports": {
+    ".": "./src/plugin.mjs",
+    "./oauth-callback": "./src/oauth-callback.mjs"
+  },
+  "files": [
+    "src/",
+    "example/",
+    "README.md",
+    "README.zh-CN.md",
+    "LICENSE"
+  ],
+  "dependencies": {
+    "@cortexkit/antigravity-auth-core": "2.1.0"
+  }
+}

--- a/packages/opencode-v2/package.json
+++ b/packages/opencode-v2/package.json
@@ -39,6 +39,12 @@
     "README.zh-CN.md",
     "LICENSE"
   ],
+  "scripts": {
+    "lint": "biome lint src example",
+    "format:check": "biome format src example README.md README.zh-CN.md",
+    "typecheck": "node --check src/plugin.mjs src/oauth-callback.mjs",
+    "test": "bun run --cwd ../core build && bun test test"
+  },
   "dependencies": {
     "@cortexkit/antigravity-auth-core": "2.1.0"
   }

--- a/packages/opencode-v2/src/oauth-callback.mjs
+++ b/packages/opencode-v2/src/oauth-callback.mjs
@@ -9,8 +9,11 @@ const CALLBACK_PATH = '/oauth-callback'
 const CALLBACK_PORT = 51121
 const CALLBACK_TIMEOUT_MS = 10 * 60_000
 
-const PAGE_OK = `<!doctype html><meta charset="utf-8"><title>Antigravity login complete</title>
-<body style="font-family:system-ui;padding:2rem"><h2>Login complete</h2><p>The account was added to OpenCode. You can close this tab.</p></body>`
+// The callback page only acknowledges that the authorization code arrived; the
+// token exchange and account persistence happen afterwards in the plugin, so the
+// page must not claim the account was added.
+const PAGE_OK = `<!doctype html><meta charset="utf-8"><title>Antigravity authorization received</title>
+<body style="font-family:system-ui;padding:2rem"><h2>Authorization received</h2><p>Return to OpenCode — the login result is reported there.</p></body>`
 const PAGE_FAIL = `<!doctype html><meta charset="utf-8"><title>Antigravity login failed</title>
 <body style="font-family:system-ui;padding:2rem"><h2>Login failed</h2><p>Return to OpenCode and try again.</p></body>`
 

--- a/packages/opencode-v2/src/oauth-callback.mjs
+++ b/packages/opencode-v2/src/oauth-callback.mjs
@@ -1,0 +1,92 @@
+// Loopback OAuth callback listener for the Antigravity login flow.
+// Google redirects to http://localhost:51121/oauth-callback (the redirect URI
+// registered for the Antigravity OAuth client), so the port is fixed.
+
+import { createServer } from 'node:http'
+
+const CALLBACK_HOST = '127.0.0.1'
+const CALLBACK_PATH = '/oauth-callback'
+const CALLBACK_PORT = 51121
+const CALLBACK_TIMEOUT_MS = 10 * 60_000
+
+const PAGE_OK = `<!doctype html><meta charset="utf-8"><title>Antigravity login complete</title>
+<body style="font-family:system-ui;padding:2rem"><h2>Login complete</h2><p>The account was added to OpenCode. You can close this tab.</p></body>`
+const PAGE_FAIL = `<!doctype html><meta charset="utf-8"><title>Antigravity login failed</title>
+<body style="font-family:system-ui;padding:2rem"><h2>Login failed</h2><p>Return to OpenCode and try again.</p></body>`
+
+function respond(response, status, page) {
+  response.writeHead(status, {
+    'cache-control': 'no-store',
+    connection: 'close',
+    'content-type': 'text/html; charset=utf-8',
+  })
+  response.end(page)
+}
+
+/**
+ * Starts listening immediately and resolves with the authorization code once
+ * Google redirects back with the matching state.
+ */
+export function waitForAntigravityCode(expectedState, options = {}) {
+  if (!expectedState) throw new Error('OAuth state is empty')
+  const port = options.port ?? CALLBACK_PORT
+  const timeoutMs = options.timeoutMs ?? CALLBACK_TIMEOUT_MS
+
+  return new Promise((resolve, reject) => {
+    let settled = false
+    let timer
+
+    const server = createServer((request, response) => {
+      let url
+      try {
+        url = new URL(request.url ?? '/', `http://${CALLBACK_HOST}:${port}`)
+      } catch {
+        respond(response, 400, PAGE_FAIL)
+        return
+      }
+      if (url.pathname !== CALLBACK_PATH) {
+        respond(response, 404, PAGE_FAIL)
+        return
+      }
+      if (url.searchParams.get('state') !== expectedState) {
+        respond(response, 400, PAGE_FAIL)
+        return
+      }
+      if (url.searchParams.has('error')) {
+        respond(response, 400, PAGE_FAIL)
+        finish(
+          undefined,
+          new Error(
+            `Google authorization failed: ${url.searchParams.get('error')}`,
+          ),
+        )
+        return
+      }
+      const code = url.searchParams.get('code')
+      if (!code) {
+        respond(response, 400, PAGE_FAIL)
+        return
+      }
+      respond(response, 200, PAGE_OK)
+      finish(code)
+    })
+
+    function finish(code, error) {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      server.close(() => {})
+      if (error) reject(error)
+      else resolve(code)
+    }
+
+    server.once('error', (error) => finish(undefined, error))
+    server.listen(port, CALLBACK_HOST, () => {
+      timer = setTimeout(
+        () =>
+          finish(undefined, new Error('Antigravity authorization timed out')),
+        timeoutMs,
+      )
+    })
+  })
+}

--- a/packages/opencode-v2/src/plugin.mjs
+++ b/packages/opencode-v2/src/plugin.mjs
@@ -1,0 +1,1000 @@
+// OpenCode V2 Antigravity provider (port of cortexkit/antigravity-auth).
+//
+// The native `@opencode-ai/ai/providers/google` package builds and parses Gemini
+// traffic, so images/PDF/tool-calls need no custom codec. A `http.request` hook
+// redirects each Antigravity model request to a loopback server owned by this
+// plugin; the server performs the real call through
+// `@cortexkit/antigravity-auth-core` (raw HTTP/1.1 transport matching the
+// Antigravity CLI, proxy aware), rotating over the multi-account pool in
+// `~/.config/opencode/antigravity-accounts.json`, and streams the unwrapped SSE
+// back to OpenCode.
+
+import { randomUUID } from 'node:crypto'
+import { appendFileSync, existsSync } from 'node:fs'
+import { createServer } from 'node:http'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+const CORE = '@cortexkit/antigravity-auth-core'
+const {
+  AccountManager,
+  defaultAccountStorageStore,
+  loadAccountStorage,
+  mutateAccountStorage,
+  formatRefreshParts,
+  refreshAntigravityToken,
+  resolveModelForHeaderStyle,
+  getModelFamily,
+  ensureProjectContext,
+  AgyRequestSessionStore,
+  buildAgyAgentRequestMetadata,
+  orderAgyRequestPayloadInPlace,
+  normalizeGeminiTools,
+  fetchWithAgyCliTransport,
+  buildAntigravityHarnessUserAgent,
+  authorizeAntigravity,
+  exchangeAntigravity,
+  parseRateLimitReason,
+  ANTIGRAVITY_ENDPOINT_FALLBACKS,
+} = await import(CORE)
+
+function configDir() {
+  const explicit = process.env.OPENCODE_CONFIG_DIR?.trim()
+  if (explicit) return explicit
+  if (process.platform === 'win32' && process.env.APPDATA?.trim()) {
+    const appdata = join(process.env.APPDATA.trim(), 'opencode')
+    if (existsSync(join(appdata, 'antigravity-accounts.json'))) return appdata
+  }
+  const xdg = process.env.XDG_CONFIG_HOME?.trim()
+  return xdg ? join(xdg, 'opencode') : join(homedir(), '.config', 'opencode')
+}
+
+function stateDir() {
+  const xdg = process.env.XDG_STATE_HOME?.trim()
+  return xdg
+    ? join(xdg, 'opencode')
+    : join(homedir(), '.local', 'state', 'opencode')
+}
+
+function dataDir() {
+  const xdg = process.env.XDG_DATA_HOME?.trim()
+  return xdg
+    ? join(xdg, 'opencode')
+    : join(homedir(), '.local', 'share', 'opencode')
+}
+
+const ACCOUNTS_FILE =
+  process.env.ANTIGRAVITY_ACCOUNTS_FILE?.trim() ||
+  join(configDir(), 'antigravity-accounts.json')
+const LOGFILE = join(stateDir(), 'antigravity-v2.log')
+const METHOD_ID = 'antigravity-v2'
+const EMPTY_RESPONSE_MAX_ATTEMPTS = 3
+
+function log(...args) {
+  try {
+    appendFileSync(
+      LOGFILE,
+      `[${new Date().toISOString()}] ` +
+        args
+          .map((x) => (typeof x === 'string' ? x : JSON.stringify(x)))
+          .join(' ') +
+        '\n',
+    )
+  } catch {}
+}
+
+const MODEL_IDS = new Set([
+  'gemini-3.7-flash',
+  'gemini-3.6-flash',
+  'gemini-3.5-flash',
+  'gemini-3.1-pro',
+  'gemini-3.1-flash-image',
+  'claude-sonnet-4-6-thinking',
+  'claude-opus-4-6-thinking',
+  'gpt-oss-120b-medium',
+])
+
+function familyFor(modelID) {
+  return getModelFamily(modelID) === 'claude' ? 'claude' : 'gemini'
+}
+
+function requestedModel(modelID, variant) {
+  if (!variant || variant === 'default') return modelID
+  return `${modelID}-${variant}`
+}
+
+function unwrapFrame(parsed) {
+  if (
+    parsed &&
+    typeof parsed === 'object' &&
+    'response' in parsed &&
+    parsed.response &&
+    typeof parsed.response === 'object'
+  ) {
+    return parsed.response
+  }
+  return parsed
+}
+
+// Antigravity's GPT/Claude bridges occasionally emit parts and roles the strict
+// native Gemini event schema rejects (e.g. role "assistant", or a part carrying
+// only a thought signature). Normalise every frame to the Gemini shape.
+function sanitizeInner(inner) {
+  const candidates = inner?.candidates
+  if (!Array.isArray(candidates)) return inner
+  for (const candidate of candidates) {
+    const content = candidate?.content
+    if (!content || typeof content !== 'object') continue
+    if (content.role !== 'user' && content.role !== 'model')
+      content.role = 'model'
+    // `parts` is required by the native schema; GPT-OSS opens a turn without it.
+    if (!Array.isArray(content.parts)) {
+      content.parts = []
+      continue
+    }
+    content.parts = content.parts
+      .map((part) => {
+        if (!part || typeof part !== 'object') return null
+        const out = {}
+        if (typeof part.text === 'string') out.text = part.text
+        if (part.thought !== undefined) out.thought = Boolean(part.thought)
+        if (typeof part.thoughtSignature === 'string')
+          out.thoughtSignature = part.thoughtSignature
+        if (part.inlineData) out.inlineData = part.inlineData
+        if (part.functionCall) out.functionCall = part.functionCall
+        if (part.functionResponse) out.functionResponse = part.functionResponse
+        if (
+          out.text === undefined &&
+          !out.inlineData &&
+          !out.functionCall &&
+          !out.functionResponse
+        ) {
+          out.text = ''
+        }
+        return out
+      })
+      .filter((part) => part !== null)
+  }
+  return inner
+}
+
+const IMAGE_DIR = join(dataDir(), 'antigravity-images')
+const IMAGE_EXTENSION = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/webp': 'webp',
+  'image/gif': 'gif',
+}
+
+// The native Gemini event parser only renders text and tool calls, so generated
+// images are written to disk and announced as text instead of being dropped.
+async function persistInlineImages(inner) {
+  const parts = inner?.candidates?.[0]?.content?.parts
+  if (!Array.isArray(parts)) return inner
+  for (let index = 0; index < parts.length; index += 1) {
+    const inline = parts[index]?.inlineData
+    if (!inline?.data || !String(inline.mimeType ?? '').startsWith('image/'))
+      continue
+    try {
+      const { mkdir, writeFile } = await import('node:fs/promises')
+      await mkdir(IMAGE_DIR, { recursive: true })
+      const extension = IMAGE_EXTENSION[inline.mimeType] ?? 'png'
+      const file = join(
+        IMAGE_DIR,
+        `${Date.now()}-${randomUUID().slice(0, 8)}.${extension}`,
+      )
+      await writeFile(file, Buffer.from(inline.data, 'base64'))
+      parts[index] = { text: `[Antigravity image saved: ${file}]` }
+      log('image-saved', file, inline.mimeType)
+    } catch (error) {
+      log('image-save-error', error?.message ?? String(error))
+      parts[index] = {
+        text: '[Antigravity returned an image that could not be saved]',
+      }
+    }
+  }
+  return inner
+}
+function retryAfterMs(response) {
+  const value = response.headers.get('retry-after')?.trim()
+  if (!value) return undefined
+  const seconds = Number(value)
+  if (Number.isFinite(seconds) && seconds > 0) return seconds * 1000
+  const date = Date.parse(value)
+  return Number.isFinite(date) && date - Date.now() > 0
+    ? date - Date.now()
+    : undefined
+}
+
+async function readErrorReason(response) {
+  try {
+    const parsed = JSON.parse(await response.clone().text())
+    const details = parsed?.error?.details ?? parsed?.details ?? []
+    return (
+      details
+        .map((item) => item?.reason)
+        .find((value) => typeof value === 'string') ?? parsed?.error?.status
+    )
+  } catch {
+    return undefined
+  }
+}
+
+function buildEnvelope(payload, resolved, projectID, metadata) {
+  const request = { ...payload }
+  delete request.model
+  delete request.project
+  delete request.user_prompt_id
+  delete request.session_id
+
+  const generationConfig = { ...(request.generationConfig ?? {}) }
+  delete generationConfig.thinkingConfig
+  if (resolved.thinkingLevel) {
+    generationConfig.thinkingConfig = {
+      includeThoughts: true,
+      thinkingLevel: resolved.thinkingLevel,
+    }
+  } else if (resolved.thinkingBudget !== undefined) {
+    generationConfig.thinkingConfig = {
+      includeThoughts: true,
+      thinkingBudget: resolved.thinkingBudget,
+    }
+  }
+  if (Object.keys(generationConfig).length > 0)
+    request.generationConfig = generationConfig
+  else delete request.generationConfig
+
+  // AGY's GPT bridge re-encodes protobuf numeric constraints as strings before
+  // OpenAI JSON-Schema validation, so `minLength: 1` must move to the description.
+  const isGpt = /^gpt-/i.test(resolved.actualModel)
+  normalizeGeminiTools(request, { moveNumericConstraintsToDescription: isGpt })
+
+  request.labels = metadata.labels
+  request.sessionId = metadata.sessionId
+  orderAgyRequestPayloadInPlace(request)
+
+  return {
+    project: projectID,
+    requestId: metadata.requestId,
+    request,
+    model: resolved.actualModel,
+    userAgent: 'antigravity',
+    requestType: 'agent',
+  }
+}
+
+export default {
+  id: 'local.antigravity',
+
+  async setup(ctx) {
+    const requestSessions = new AgyRequestSessionStore('opencode-v2')
+    const jobs = new Map()
+
+    let accounts = await loadAccountStorage(ACCOUNTS_FILE).catch((error) => {
+      log('accounts-load-error', error?.message ?? String(error))
+      return null
+    })
+    let manager = new AccountManager(undefined, accounts, {
+      store: defaultAccountStorageStore,
+      storagePath: ACCOUNTS_FILE,
+    })
+    log('setup-start', 'accounts', manager.getTotalAccountCount())
+
+    const reloadPool = async () => {
+      try {
+        await manager.flushSaveToDisk().catch(() => {})
+        accounts = await loadAccountStorage(ACCOUNTS_FILE)
+        manager = new AccountManager(undefined, accounts, {
+          store: defaultAccountStorageStore,
+          storagePath: ACCOUNTS_FILE,
+        })
+        log('pool-reloaded', manager.getTotalAccountCount())
+      } catch (error) {
+        log('reload-pool-error', error?.message ?? String(error))
+      }
+    }
+
+    async function accessFor(account, force = false) {
+      if (
+        !force &&
+        account.access &&
+        account.expires &&
+        account.expires > Date.now() + 60_000
+      ) {
+        return manager.toAuthDetails(account)
+      }
+      const refreshed = await refreshAntigravityToken(
+        account.parts.refreshToken,
+      )
+      const auth = {
+        type: 'oauth',
+        refresh: formatRefreshParts({
+          refreshToken: refreshed.refresh,
+          projectId: account.parts.projectId,
+          managedProjectId: account.parts.managedProjectId,
+        }),
+        access: refreshed.access,
+        expires: refreshed.expires,
+      }
+      manager.updateFromAuth(account, auth)
+      return auth
+    }
+
+    function send(envelope, auth, endpoint, signal) {
+      return fetchWithAgyCliTransport(
+        `${endpoint}/v1internal:streamGenerateContent?alt=sse`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${auth.access}`,
+            'Content-Type': 'application/json',
+            Accept: 'text/event-stream',
+            'Accept-Encoding': 'gzip',
+            'User-Agent': buildAntigravityHarnessUserAgent(),
+          },
+          body: JSON.stringify(envelope),
+        },
+        { signal: signal ?? null, idleTimeoutMs: 300_000 },
+      )
+    }
+
+    async function pickResponse(job, signal) {
+      const family = familyFor(job.modelID)
+      const requested = requestedModel(job.modelID, job.variant)
+      const identity = { id: job.sessionID ?? 'default', parentId: null }
+      const excluded = new Set()
+      const poolSize = Math.max(1, manager.getEnabledAccounts().length)
+      let failure = null
+
+      for (let attempt = 0; attempt < poolSize + 2; attempt += 1) {
+        const account = manager.getCurrentOrNextForFamily(
+          family,
+          requested,
+          'hybrid',
+          'antigravity',
+          false,
+          100,
+          10 * 60_000,
+          identity,
+          excluded,
+        )
+        if (!account) break
+
+        let auth
+        try {
+          auth = await accessFor(account)
+        } catch (error) {
+          log(
+            'token-error',
+            `#${account.index}`,
+            error?.message ?? String(error),
+          )
+          excluded.add(account.index)
+          failure = error
+          continue
+        }
+
+        let context
+        try {
+          context = await ensureProjectContext(auth)
+        } catch (error) {
+          log(
+            'project-error',
+            `#${account.index}`,
+            error?.message ?? String(error),
+          )
+          excluded.add(account.index)
+          failure = error
+          continue
+        }
+
+        const scope = requestSessions.beginRequest(
+          String(job.sessionID ?? '__default__'),
+        )
+        const metadata = buildAgyAgentRequestMetadata(
+          scope.session,
+          job.payload,
+          job.resolved.actualModel,
+          scope.timestamp,
+          {
+            stepCountMode: 'cli',
+          },
+        )
+        const envelope = buildEnvelope(
+          job.payload,
+          job.resolved,
+          context.effectiveProjectId,
+          metadata,
+        )
+
+        for (
+          let endpointIndex = 0;
+          endpointIndex < ANTIGRAVITY_ENDPOINT_FALLBACKS.length;
+          endpointIndex += 1
+        ) {
+          const endpoint = ANTIGRAVITY_ENDPOINT_FALLBACKS[endpointIndex]
+          let response
+          try {
+            response = await send(envelope, auth, endpoint, signal)
+          } catch (error) {
+            log(
+              'transport-error',
+              `#${account.index}`,
+              endpoint,
+              error?.message ?? String(error),
+            )
+            failure = error
+            continue
+          }
+          log(
+            'upstream',
+            `#${account.index}`,
+            endpoint,
+            job.resolved.actualModel,
+            response.status,
+          )
+
+          if (response.ok) {
+            manager.markRequestSuccess(account)
+            manager.markAccountUsed(account.index)
+            manager.recordRequest(account.index, family)
+            manager.requestSaveToDisk()
+            return { response, account }
+          }
+
+          const reason = await readErrorReason(response)
+          if (!response.ok) {
+            const detail = await response
+              .clone()
+              .text()
+              .catch(() => '')
+            let message = ''
+            try {
+              message = JSON.parse(detail)?.error?.message ?? ''
+            } catch {
+              message = detail.slice(0, 200)
+            }
+            log(
+              'upstream-error',
+              response.status,
+              reason ?? '',
+              message.slice(0, 300),
+            )
+          }
+          if (
+            response.status === 404 &&
+            endpointIndex < ANTIGRAVITY_ENDPOINT_FALLBACKS.length - 1
+          )
+            continue
+
+          if (response.status === 401) {
+            try {
+              auth = await accessFor(account, true)
+              endpointIndex -= 1
+              continue
+            } catch (error) {
+              failure = error
+            }
+            excluded.add(account.index)
+            break
+          }
+
+          if (response.status === 429 || response.status === 403) {
+            const limit =
+              parseRateLimitReason(reason, '', response.status) || 'RATE_LIMIT'
+            manager.markRateLimitedWithReason(
+              account,
+              family,
+              'antigravity',
+              requested,
+              limit,
+              retryAfterMs(response) ?? 60_000,
+              3_600_000,
+            )
+            excluded.add(account.index)
+            failure = new Error(
+              `Antigravity ${response.status}${reason ? ` (${reason})` : ''}`,
+            )
+            break
+          }
+
+          failure = new Error(
+            `Antigravity HTTP ${response.status}${reason ? ` (${reason})` : ''}`,
+          )
+          excluded.add(account.index)
+          break
+        }
+      }
+
+      throw (
+        failure ??
+        new Error(
+          'No Antigravity account available (all rate-limited or disabled)',
+        )
+      )
+    }
+
+    // Streams one upstream SSE response into the loopback response, unwrapping the
+    // `{ "response": … }` Antigravity envelope. Reports whether any model content
+    // arrived so a bare STOP can be retried.
+    async function pipeStream(upstream, res) {
+      const reader = upstream.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+      let sawContent = false
+      let terminal = false
+      try {
+        while (!terminal) {
+          const { done, value } = await reader.read()
+          if (done) break
+          buffer += decoder.decode(value, { stream: true })
+          buffer = buffer.replace(/\r\n/g, '\n')
+          let boundary = buffer.indexOf('\n\n')
+          while (boundary !== -1) {
+            const frame = buffer.slice(0, boundary)
+            buffer = buffer.slice(boundary + 2)
+            boundary = buffer.indexOf('\n\n')
+            const data = frame
+              .split('\n')
+              .filter((line) => line.startsWith('data:'))
+              .map((line) => line.slice(5).replace(/^ /, ''))
+              .join('\n')
+              .trim()
+            if (!data || data === '[DONE]') continue
+            let parsed
+            try {
+              parsed = JSON.parse(data)
+            } catch {
+              continue
+            }
+            const inner = await persistInlineImages(
+              sanitizeInner(unwrapFrame(parsed)),
+            )
+            const parts = inner?.candidates?.[0]?.content?.parts ?? []
+            if (
+              parts.some(
+                (part) => part?.text || part?.functionCall || part?.inlineData,
+              )
+            )
+              sawContent = true
+            res.write(`data: ${JSON.stringify(inner)}\n\n`)
+            if (inner?.candidates?.[0]?.finishReason) {
+              terminal = true
+              break
+            }
+          }
+        }
+      } finally {
+        try {
+          await reader.cancel()
+        } catch {}
+      }
+      return { sawContent, terminal }
+    }
+
+    // Collects one complete Antigravity answer (used by the document tool).
+    async function collectText(upstream) {
+      const reader = upstream.body.getReader()
+      const decoder = new TextDecoder()
+      const LF = String.fromCharCode(10)
+      const CR = String.fromCharCode(13)
+      let buffer = ''
+      const chunks = []
+      const images = []
+      let done = false
+      try {
+        while (!done) {
+          const { done: finished, value } = await reader.read()
+          if (finished) break
+          buffer += decoder.decode(value, { stream: true })
+          buffer = buffer.split(CR).join('')
+          let boundary = buffer.indexOf(LF + LF)
+          while (boundary !== -1) {
+            const frame = buffer.slice(0, boundary)
+            buffer = buffer.slice(boundary + 2)
+            boundary = buffer.indexOf(LF + LF)
+            const data = frame
+              .split(LF)
+              .filter((line) => line.startsWith('data:'))
+              .map((line) => line.slice(5).trimStart())
+              .join(LF)
+              .trim()
+            if (!data || data === '[DONE]') continue
+            let parsed
+            try {
+              parsed = JSON.parse(data)
+            } catch {
+              continue
+            }
+            const inner = unwrapFrame(parsed)
+            for (const part of inner?.candidates?.[0]?.content?.parts ?? []) {
+              if (part?.thought) continue
+              if (typeof part?.text === 'string' && part.text)
+                chunks.push(part.text)
+              if (part?.inlineData?.data) images.push(part.inlineData)
+            }
+            if (inner?.candidates?.[0]?.finishReason) {
+              done = true
+              break
+            }
+          }
+        }
+      } finally {
+        try {
+          await reader.cancel()
+        } catch {}
+      }
+      return { text: chunks.join(''), images }
+    }
+
+    const DOCUMENT_MIME = {
+      '.pdf': 'application/pdf',
+      '.png': 'image/png',
+      '.jpg': 'image/jpeg',
+      '.jpeg': 'image/jpeg',
+      '.webp': 'image/webp',
+      '.gif': 'image/gif',
+      '.heic': 'image/heic',
+      '.heif': 'image/heif',
+    }
+
+    const server = createServer((req, res) => {
+      const id = (req.url ?? '').split('/').filter(Boolean).pop() ?? ''
+      const job = jobs.get(id)
+      jobs.delete(id)
+      req.resume()
+      if (!job) {
+        res.writeHead(404, { 'content-type': 'application/json' })
+        res.end(
+          JSON.stringify({
+            error: { message: 'unknown antigravity request', status: 404 },
+          }),
+        )
+        return
+      }
+      const controller = new AbortController()
+      res.on('close', () => controller.abort())
+
+      ;(async () => {
+        let lastError = null
+        for (
+          let attempt = 1;
+          attempt <= EMPTY_RESPONSE_MAX_ATTEMPTS;
+          attempt += 1
+        ) {
+          let picked
+          try {
+            picked = await pickResponse(job, controller.signal)
+          } catch (error) {
+            lastError = error
+            break
+          }
+          if (!res.headersSent) {
+            res.writeHead(200, {
+              'content-type': 'text/event-stream; charset=utf-8',
+              'cache-control': 'no-cache',
+            })
+          }
+          const { sawContent, terminal } = await pipeStream(
+            picked.response,
+            res,
+          )
+          log(
+            'stream-done',
+            job.modelID,
+            'content',
+            sawContent,
+            'terminal',
+            terminal,
+            'attempt',
+            attempt,
+          )
+          if (sawContent || attempt === EMPTY_RESPONSE_MAX_ATTEMPTS) {
+            res.end()
+            return
+          }
+          await new Promise((resolve) => setTimeout(resolve, 1_000))
+        }
+        const message =
+          lastError?.message ??
+          String(lastError ?? 'Antigravity request failed')
+        log('request-failed', job.modelID, message)
+        if (!res.headersSent) {
+          res.writeHead(502, { 'content-type': 'application/json' })
+          res.end(JSON.stringify({ error: { message, status: 502 } }))
+        } else {
+          res.end()
+        }
+      })().catch((error) => {
+        log('server-error', error?.message ?? String(error))
+        try {
+          if (!res.headersSent) {
+            res.writeHead(502, { 'content-type': 'application/json' })
+            res.end(
+              JSON.stringify({
+                error: {
+                  message: error?.message ?? String(error),
+                  status: 502,
+                },
+              }),
+            )
+          } else {
+            res.end()
+          }
+        } catch {}
+      })
+    })
+
+    await new Promise((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', () => {
+        server.off('error', reject)
+        resolve()
+      })
+    })
+    const port = server.address().port
+    log('loopback-listening', port)
+
+    await ctx.session.hook('http.request', async (event) => {
+      try {
+        if (event.model.providerID !== 'google') return
+        if (!MODEL_IDS.has(event.model.id)) return
+        const url = new URL(event.request.url)
+        if (
+          !/\/models\/[^:]+:(?:streamGenerateContent|generateContent)/.test(
+            url.pathname,
+          )
+        )
+          return
+
+        const raw = Buffer.from(await event.request.arrayBuffer()).toString(
+          'utf8',
+        )
+        const payload = JSON.parse(raw || '{}')
+        const requested = requestedModel(event.model.id, event.model.variant)
+        const resolved = resolveModelForHeaderStyle(requested, 'antigravity')
+        const id = randomUUID()
+        jobs.set(id, {
+          payload,
+          resolved,
+          modelID: event.model.id,
+          variant: event.model.variant,
+          sessionID: event.sessionID,
+        })
+        setTimeout(() => jobs.delete(id), 10 * 60_000)
+        const attachments = (payload.contents ?? [])
+          .flatMap((content) => content?.parts ?? [])
+          .filter((part) => part?.inlineData)
+          .map(
+            (part) =>
+              `${part.inlineData.mimeType}:${String(part.inlineData.data ?? '').length}b`,
+          )
+        log(
+          'route',
+          event.model.id,
+          event.model.variant ?? 'default',
+          '->',
+          resolved.actualModel,
+          'media',
+          JSON.stringify(attachments),
+        )
+        event.request = new Request(`http://127.0.0.1:${port}/agy/${id}`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: '{}',
+        })
+      } catch (error) {
+        log('request-hook-error', error?.message ?? String(error))
+      }
+    })
+
+    // PDF / image reader. OpenCode's CLI drops PDF attachments before they reach
+    // the provider, so the plugin loads the document itself and asks Antigravity
+    // directly — the same "reuse the working channel" approach as ModLens.
+    await ctx.tool.transform((draft) => {
+      draft.add({
+        name: 'antigravity_read_document',
+        description:
+          'Read a local PDF or image with an Antigravity multimodal model and return its text. Use for .pdf, .png, .jpg, .webp, .gif, .heic files. Arguments: path (absolute), question (optional), model (optional, defaults to gemini-3.6-flash).',
+        input: {
+          type: 'object',
+          properties: {
+            path: {
+              type: 'string',
+              description: 'Absolute path to the PDF or image file',
+            },
+            question: {
+              type: 'string',
+              description: 'What to extract or ask about the document',
+            },
+            model: {
+              type: 'string',
+              description:
+                'Antigravity model id, e.g. gemini-3.6-flash or gemini-3.1-pro',
+            },
+          },
+          required: ['path'],
+        },
+        async execute(input) {
+          const { readFile } = await import('node:fs/promises')
+          const { extname, basename } = await import('node:path')
+          const path = String(input?.path ?? '').trim()
+          if (!path)
+            return { content: 'antigravity_read_document: `path` is required' }
+          const extension = extname(path).toLowerCase()
+          const mimeType = DOCUMENT_MIME[extension]
+          if (!mimeType) {
+            return {
+              content: `antigravity_read_document: unsupported file type ${extension || '(none)'}`,
+            }
+          }
+          let data
+          try {
+            data = (await readFile(path)).toString('base64')
+          } catch (error) {
+            return {
+              content: `antigravity_read_document: cannot read ${path}: ${error?.message ?? String(error)}`,
+            }
+          }
+          const question =
+            String(input?.question ?? '').trim() ||
+            'Transcribe this document completely and describe any tables, figures or layout that matter.'
+          const modelID = MODEL_IDS.has(String(input?.model))
+            ? String(input.model)
+            : 'gemini-3.6-flash'
+          const variant =
+            modelID.startsWith('gemini-3.') && !modelID.includes('image')
+              ? 'high'
+              : undefined
+          const resolved = resolveModelForHeaderStyle(
+            requestedModel(modelID, variant),
+            'antigravity',
+          )
+          const job = {
+            payload: {
+              contents: [
+                {
+                  role: 'user',
+                  parts: [
+                    { inlineData: { mimeType, data } },
+                    { text: question },
+                  ],
+                },
+              ],
+            },
+            resolved,
+            modelID,
+            variant,
+            sessionID: `tool:${basename(path)}`,
+          }
+          log(
+            'tool-read',
+            basename(path),
+            mimeType,
+            data.length,
+            '->',
+            resolved.actualModel,
+          )
+          const picked = await pickResponse(job, undefined)
+          const { text, images } = await collectText(picked.response)
+          if (!text && images.length === 0)
+            return {
+              content:
+                'antigravity_read_document: the model returned no content',
+            }
+          const content = []
+          if (text) content.push({ type: 'text', text })
+          for (const image of images) {
+            content.push({
+              type: 'file',
+              mime: image.mimeType ?? 'image/png',
+              uri: `data:${image.mimeType ?? 'image/png'};base64,${image.data}`,
+              name: `${basename(path)}-output`,
+            })
+          }
+          return {
+            content,
+            metadata: {
+              model: resolved.actualModel,
+              file: basename(path),
+              mime: mimeType,
+            },
+          }
+        },
+      })
+    })
+
+    // OAuth: every login appends an account to the shared pool.
+    await ctx.integration.transform((draft) => {
+      draft.method.update({
+        integrationID: 'google',
+        method: {
+          id: METHOD_ID,
+          type: 'oauth',
+          label: 'Google Antigravity (add account)',
+        },
+        authorize: async () => {
+          const authorization = await authorizeAntigravity()
+          const state = new URL(authorization.url).searchParams.get('state')
+          if (!state)
+            throw new Error(
+              'Antigravity authorization URL is missing OAuth state',
+            )
+          const { waitForAntigravityCode } = await import(
+            './oauth-callback.mjs'
+          )
+          const pending = waitForAntigravityCode(state)
+          return {
+            url: authorization.url,
+            instructions:
+              'Open the URL and sign in. The Google account is appended to the Antigravity pool.',
+            mode: 'auto',
+            callback: async () => {
+              const code = await pending
+              const result = await exchangeAntigravity(code, state)
+              if (result.type === 'failed')
+                throw new Error(
+                  `Antigravity token exchange failed: ${result.error}`,
+                )
+              const now = Date.now()
+              await mutateAccountStorage(ACCOUNTS_FILE, (current) => ({
+                ...current,
+                version: 4,
+                accounts: [
+                  ...current.accounts.filter(
+                    (item) => item.email !== result.email,
+                  ),
+                  {
+                    email: result.email,
+                    refreshToken: result.refresh,
+                    projectId: result.projectId || undefined,
+                    addedAt: now,
+                    lastUsed: now,
+                    enabled: true,
+                    rateLimitResetTimes: {},
+                  },
+                ],
+              }))
+              await reloadPool()
+              log('account-added', 'pool', manager.getTotalAccountCount())
+              return {
+                type: 'oauth',
+                methodID: METHOD_ID,
+                refresh: result.refresh,
+                access: result.access,
+                expires: result.expires,
+                metadata: {
+                  accountID: result.email ?? '',
+                  projectID: result.projectId ?? '',
+                },
+              }
+            },
+          }
+        },
+        refresh: async (credential) => {
+          const refreshToken = String(credential.refresh ?? '').split('|')[0]
+          const refreshed = await refreshAntigravityToken(refreshToken)
+          return {
+            type: 'oauth',
+            methodID: METHOD_ID,
+            refresh: formatRefreshParts({ refreshToken: refreshed.refresh }),
+            access: refreshed.access,
+            expires: refreshed.expires,
+            ...(credential.metadata ? { metadata: credential.metadata } : {}),
+          }
+        },
+        label: (credential) =>
+          credential?.metadata?.accountID || 'Antigravity account',
+      })
+    })
+
+    return async () => {
+      try {
+        await manager.flushSaveToDisk()
+        await manager.dispose()
+      } catch {}
+      await new Promise((resolve) => server.close(() => resolve()))
+      log('dispose')
+    }
+  },
+}

--- a/packages/opencode-v2/src/plugin.mjs
+++ b/packages/opencode-v2/src/plugin.mjs
@@ -970,7 +970,7 @@ export default {
           required: ['path'],
         },
         async execute(input) {
-          const { readFile } = await import('node:fs/promises')
+          const { readFile, realpath } = await import('node:fs/promises')
           const { extname, basename } = await import('node:path')
           const path = String(input?.path ?? '').trim()
           if (!path)
@@ -990,7 +990,17 @@ export default {
           }
           let data
           try {
-            data = (await readFile(path)).toString('base64')
+            // Resolve symlinks/junctions before reading: the lexical path can
+            // sit inside an allowed root while the real target lives outside
+            // it. The boundary is enforced on the real path as well.
+            const real = await realpath(path)
+            if (!isPathAllowed(real)) {
+              return {
+                content:
+                  'antigravity_read_document: access denied — the real path of this file is outside the allowed document roots or is a protected file. Configure the plugin option `readDocumentRoots` to allow specific directories.',
+              }
+            }
+            data = (await readFile(real)).toString('base64')
           } catch (error) {
             return {
               content: `antigravity_read_document: cannot read ${path}: ${error?.message ?? String(error)}`,

--- a/packages/opencode-v2/src/plugin.mjs
+++ b/packages/opencode-v2/src/plugin.mjs
@@ -267,6 +267,7 @@ export default {
   id: 'local.antigravity',
 
   async setup(ctx) {
+    const options = ctx.options ?? {}
     const requestSessions = new AgyRequestSessionStore('opencode-v2')
     const jobs = new Map()
 
@@ -407,6 +408,10 @@ export default {
           metadata,
         )
 
+        // A forced refresh happens at most once per account/request; if the
+        // endpoint still answers 401 afterwards the account is excluded and the
+        // pool selection continues instead of refreshing in an unbounded loop.
+        let forcedRefresh = false
         for (
           let endpointIndex = 0;
           endpointIndex < ANTIGRAVITY_ENDPOINT_FALLBACKS.length;
@@ -468,12 +473,15 @@ export default {
             continue
 
           if (response.status === 401) {
-            try {
-              auth = await accessFor(account, true)
-              endpointIndex -= 1
-              continue
-            } catch (error) {
-              failure = error
+            if (!forcedRefresh) {
+              try {
+                auth = await accessFor(account, true)
+                forcedRefresh = true
+                endpointIndex -= 1
+                continue
+              } catch (error) {
+                failure = error
+              }
             }
             excluded.add(account.index)
             break
@@ -627,6 +635,83 @@ export default {
       return { text: chunks.join(''), images }
     }
 
+    // Collects one upstream SSE stream into a single JSON GenerateContentResponse
+    // (used when the host issued a non-streaming `generateContent` call — the
+    // loopback must not answer that with `text/event-stream`).
+    async function collectNonStream(upstream) {
+      const reader = upstream.body.getReader()
+      const decoder = new TextDecoder()
+      const LF = String.fromCharCode(10)
+      const CR = String.fromCharCode(13)
+      let buffer = ''
+      const byIndex = new Map()
+      let usageMetadata
+      let promptFeedback
+      try {
+        let terminal = false
+        while (!terminal) {
+          const { done, value } = await reader.read()
+          if (done) break
+          buffer += decoder.decode(value, { stream: true })
+          buffer = buffer.split(CR).join('')
+          let boundary = buffer.indexOf(LF + LF)
+          while (boundary !== -1) {
+            const frame = buffer.slice(0, boundary)
+            buffer = buffer.slice(boundary + 2)
+            boundary = buffer.indexOf(LF + LF)
+            const data = frame
+              .split(LF)
+              .filter((line) => line.startsWith('data:'))
+              .map((line) => line.slice(5).trimStart())
+              .join(LF)
+              .trim()
+            if (!data || data === '[DONE]') continue
+            let parsed
+            try {
+              parsed = JSON.parse(data)
+            } catch {
+              continue
+            }
+            const inner = sanitizeInner(unwrapFrame(parsed))
+            for (const candidate of inner?.candidates ?? []) {
+              const index = candidate.index ?? 0
+              let entry = byIndex.get(index)
+              if (!entry) {
+                entry = {
+                  ...candidate,
+                  content: { ...(candidate.content ?? {}) },
+                }
+                entry.content.parts = []
+                byIndex.set(index, entry)
+              }
+              for (const part of candidate.content?.parts ?? []) {
+                if (part?.text || part?.inlineData || part?.functionCall)
+                  entry.content.parts.push(part)
+              }
+              if (candidate.finishReason)
+                entry.finishReason = candidate.finishReason
+              if (candidate.thought) entry.thought = candidate.thought
+              if (candidate.index !== undefined) entry.index = index
+            }
+            if (inner?.usageMetadata) usageMetadata = inner.usageMetadata
+            if (inner?.promptFeedback) promptFeedback = inner.promptFeedback
+            if (inner?.candidates?.some((candidate) => candidate.finishReason))
+              terminal = true
+          }
+        }
+      } finally {
+        try {
+          await reader.cancel()
+        } catch {}
+      }
+      const merged = {
+        candidates: [...byIndex.values()],
+        ...(usageMetadata ? { usageMetadata } : {}),
+        ...(promptFeedback ? { promptFeedback } : {}),
+      }
+      return persistInlineImages(merged)
+    }
+
     const DOCUMENT_MIME = {
       '.pdf': 'application/pdf',
       '.png': 'image/png',
@@ -636,6 +721,32 @@ export default {
       '.gif': 'image/gif',
       '.heic': 'image/heic',
       '.heif': 'image/heif',
+    }
+
+    // The document tool is a prompt-injection vector: an untrusted PDF/image can
+    // instruct the model to call it on sensitive local files. Always block the
+    // classic credential/secret locations, and narrow the readable root with the
+    // `readDocumentRoots` plugin option when a stricter policy is wanted.
+    const READ_DENYLIST =
+      /(^|[\\/])(\.ssh|\.gnupg|\.aws|\.azure|\.config|\.local|\.cache|AppData)([\\/]|$)|\.(?:env|key|pem|p12|pfx|p8|asc|gpg)$|(^|[\\/])(?:id_rsa|id_ed25519|id_ecdsa|credentials|secrets?|tokens?|auth\.json|antigravity-accounts\.json)(?:\.|$)/i
+    const readDocumentRoots = [options.readDocumentRoots ?? []]
+      .flat()
+      .map((root) => String(root).trim())
+      .filter(Boolean)
+
+    function isPathAllowed(documentPath) {
+      const normalized = path.resolve(documentPath).replace(/\\/g, '/')
+      if (READ_DENYLIST.test(normalized)) return false
+      if (readDocumentRoots.length === 0) {
+        // Default: anything under the user's home directory (sensitive paths
+        // above are still blocked). Configure `readDocumentRoots` to restrict.
+        const home = homedir().replace(/\\/g, '/')
+        return normalized === home || normalized.startsWith(`${home}/`)
+      }
+      return readDocumentRoots.some((root) => {
+        const base = path.resolve(root).replace(/\\/g, '/')
+        return normalized === base || normalized.startsWith(`${base}/`)
+      })
     }
 
     const server = createServer((req, res) => {
@@ -669,6 +780,45 @@ export default {
             lastError = error
             break
           }
+          const finish = (body) => {
+            requestSessions.completeExecution(
+              String(job.sessionID ?? '__default__'),
+            )
+            if (!res.headersSent) {
+              res.writeHead(200, {
+                'content-type':
+                  job.stream === false
+                    ? 'application/json; charset=utf-8'
+                    : 'text/event-stream; charset=utf-8',
+                'cache-control': 'no-cache',
+              })
+            }
+            res.end(body)
+          }
+          if (job.stream === false) {
+            const collected = await collectNonStream(picked.response)
+            const sawContent =
+              collected.candidates?.some((candidate) =>
+                candidate?.content?.parts?.some(
+                  (part) =>
+                    part?.text || part?.functionCall || part?.inlineData,
+                ),
+              ) ?? false
+            log(
+              'non-stream-done',
+              job.modelID,
+              'content',
+              sawContent,
+              'attempt',
+              attempt,
+            )
+            if (sawContent || attempt === EMPTY_RESPONSE_MAX_ATTEMPTS) {
+              finish(JSON.stringify(collected))
+              return
+            }
+            await new Promise((resolve) => setTimeout(resolve, 1_000))
+            continue
+          }
           if (!res.headersSent) {
             res.writeHead(200, {
               'content-type': 'text/event-stream; charset=utf-8',
@@ -690,7 +840,7 @@ export default {
             attempt,
           )
           if (sawContent || attempt === EMPTY_RESPONSE_MAX_ATTEMPTS) {
-            res.end()
+            finish()
             return
           }
           await new Promise((resolve) => setTimeout(resolve, 1_000))
@@ -760,6 +910,9 @@ export default {
           modelID: event.model.id,
           variant: event.model.variant,
           sessionID: event.sessionID,
+          // The hook matches both endpoints; the loopback answers the streaming
+          // one with SSE and the non-streaming one with a single JSON response.
+          stream: /streamGenerateContent/.test(url.pathname),
         })
         setTimeout(() => jobs.delete(id), 10 * 60_000)
         const attachments = (payload.contents ?? [])
@@ -795,13 +948,14 @@ export default {
       draft.add({
         name: 'antigravity_read_document',
         description:
-          'Read a local PDF or image with an Antigravity multimodal model and return its text. Use for .pdf, .png, .jpg, .webp, .gif, .heic files. Arguments: path (absolute), question (optional), model (optional, defaults to gemini-3.6-flash).',
+          'Read a local PDF or image with an Antigravity multimodal model and return its text. Use for .pdf, .png, .jpg, .webp, .gif, .heic files. Arguments: path (absolute), question (optional), model (optional, defaults to gemini-3.6-flash). Only files under the configured document roots can be read; credential, secret and private-key files are always refused.',
         input: {
           type: 'object',
           properties: {
             path: {
               type: 'string',
-              description: 'Absolute path to the PDF or image file',
+              description:
+                'Absolute path to the PDF or image file (must be inside the configured document roots)',
             },
             question: {
               type: 'string',
@@ -821,6 +975,12 @@ export default {
           const path = String(input?.path ?? '').trim()
           if (!path)
             return { content: 'antigravity_read_document: `path` is required' }
+          if (!isPathAllowed(path)) {
+            return {
+              content:
+                'antigravity_read_document: access denied — this path is outside the allowed document roots or is a protected file. Configure the plugin option `readDocumentRoots` to allow specific directories.',
+            }
+          }
           const extension = extname(path).toLowerCase()
           const mimeType = DOCUMENT_MIME[extension]
           if (!mimeType) {
@@ -877,6 +1037,9 @@ export default {
           )
           const picked = await pickResponse(job, undefined)
           const { text, images } = await collectText(picked.response)
+          requestSessions.completeExecution(
+            String(job.sessionID ?? '__default__'),
+          )
           if (!text && images.length === 0)
             return {
               content:

--- a/packages/opencode-v2/src/plugin.mjs
+++ b/packages/opencode-v2/src/plugin.mjs
@@ -10,7 +10,7 @@
 // back to OpenCode.
 
 import { randomUUID } from 'node:crypto'
-import { appendFileSync, existsSync } from 'node:fs'
+import { appendFileSync, existsSync, realpathSync } from 'node:fs'
 import { createServer } from 'node:http'
 import { homedir } from 'node:os'
 import { join, resolve } from 'node:path'
@@ -733,6 +733,15 @@ export default {
       .flat()
       .map((root) => String(root).trim())
       .filter(Boolean)
+      // Canonicalize configured roots so a root that is itself a symlink or
+      // junction keeps matching the real (resolved) document paths.
+      .map((root) => {
+        try {
+          return realpathSync(root)
+        } catch {
+          return resolve(root)
+        }
+      })
 
     function isPathAllowed(documentPath) {
       const normalized = resolve(documentPath).replace(/\\/g, '/')
@@ -975,12 +984,6 @@ export default {
           const path = String(input?.path ?? '').trim()
           if (!path)
             return { content: 'antigravity_read_document: `path` is required' }
-          if (!isPathAllowed(path)) {
-            return {
-              content:
-                'antigravity_read_document: access denied — this path is outside the allowed document roots or is a protected file. Configure the plugin option `readDocumentRoots` to allow specific directories.',
-            }
-          }
           const extension = extname(path).toLowerCase()
           const mimeType = DOCUMENT_MIME[extension]
           if (!mimeType) {
@@ -990,9 +993,10 @@ export default {
           }
           let data
           try {
-            // Resolve symlinks/junctions before reading: the lexical path can
-            // sit inside an allowed root while the real target lives outside
-            // it. The boundary is enforced on the real path as well.
+            // Canonicalize the target before reading: the boundary is enforced
+            // on the real path, so caller-supplied symlinks/junctions cannot
+            // escape a configured root, while roots that are themselves
+            // junctions/symlinks stay usable (they are canonicalized too).
             const real = await realpath(path)
             if (!isPathAllowed(real)) {
               return {

--- a/packages/opencode-v2/src/plugin.mjs
+++ b/packages/opencode-v2/src/plugin.mjs
@@ -13,7 +13,7 @@ import { randomUUID } from 'node:crypto'
 import { appendFileSync, existsSync } from 'node:fs'
 import { createServer } from 'node:http'
 import { homedir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 
 const CORE = '@cortexkit/antigravity-auth-core'
 const {
@@ -735,7 +735,7 @@ export default {
       .filter(Boolean)
 
     function isPathAllowed(documentPath) {
-      const normalized = path.resolve(documentPath).replace(/\\/g, '/')
+      const normalized = resolve(documentPath).replace(/\\/g, '/')
       if (READ_DENYLIST.test(normalized)) return false
       if (readDocumentRoots.length === 0) {
         // Default: anything under the user's home directory (sensitive paths
@@ -744,7 +744,7 @@ export default {
         return normalized === home || normalized.startsWith(`${home}/`)
       }
       return readDocumentRoots.some((root) => {
-        const base = path.resolve(root).replace(/\\/g, '/')
+        const base = resolve(root).replace(/\\/g, '/')
         return normalized === base || normalized.startsWith(`${base}/`)
       })
     }

--- a/packages/opencode-v2/test/plugin.test.mjs
+++ b/packages/opencode-v2/test/plugin.test.mjs
@@ -1,0 +1,15 @@
+// Smoke test for the OpenCode 2.x host adapter: the plugin module must load
+// (which imports the shared core) and expose the documented plugin contract.
+import { describe, expect, test } from 'bun:test'
+
+describe('opencode-v2-antigravity-auth plugin entry', () => {
+  test('exports the plugin contract shape', async () => {
+    // Dynamic import: the plugin module starts with a top-level `await import`
+    // of the shared core, which does not mix well with a static import binding
+    // under the test runner.
+    const { default: plugin } = await import('../src/plugin.mjs')
+    expect(plugin).toBeTypeOf('object')
+    expect(plugin.id).toBe('local.antigravity')
+    expect(plugin.setup).toBeTypeOf('function')
+  })
+})

--- a/scripts/version-sync.mjs
+++ b/scripts/version-sync.mjs
@@ -20,6 +20,7 @@ const packageJsonPaths = [
   join(root, 'packages', 'core', 'package.json'),
   join(root, 'packages', 'opencode', 'package.json'),
   join(root, 'packages', 'pi', 'package.json'),
+  join(root, 'packages', 'opencode-v2', 'package.json'),
 ]
 
 function parseArgs(argv) {


### PR DESCRIPTION
### Title

Add an OpenCode 2.x host adapter (reuses the existing core, no changes to the 1.x package)

### Background

OpenCode 2.x (`@opencode-ai/cli@0.0.0-beta-*`, binary `opencode2`) replaced the plugin surface:

- no `fetch()` patching; instead `session.hook("http.request" | "http.response")`;
- providers are declared with native packages in config, e.g.
  `"package": "@opencode-ai/ai/providers/google"`;
- OAuth methods are registered through `integration.transform`, tools through `tool.transform`;
- the existing `@cortexkit/opencode-antigravity-auth` declares
  `engines.opencode: ">=1.17.13 <2"` and cannot load on 2.x (neither the TUI sidebar nor the
  `fetch` patch exist there).

So 2.x users currently have no Antigravity access. I wrote the host adapter; all logic still
comes from `@cortexkit/antigravity-auth-core@2.1.0` — OAuth, transport, account pool, quota and
the model registry are untouched.

### Implementation

1. `session.hook("http.request")` intercepts Antigravity model calls and rewrites the URL to a
   loopback server owned by the plugin.
   Why a loopback server: 2.x sends whatever `event.request` the hook leaves behind through its
   own HTTP client, and `http.response` only runs after that request succeeded, so a custom
   `Response` cannot be returned from the hook. The loopback keeps the core's
   `fetchWithAgyCliTransport` (agy header order, proxy support) while the host still sees a
   plain, streamable, cancellable SSE.
2. Inside the loopback: `getCurrentOrNextForFamily` (hybrid) → `refreshAntigravityToken` →
   `ensureProjectContext` → `buildAgyAgentRequestMetadata` +
   `orderAgyRequestPayloadInPlace` → `ANTIGRAVITY_ENDPOINT_FALLBACKS`.
   `429/403` cools the account down via `markRateLimitedWithReason` and rotates, `401` forces a
   refresh, and an empty-candidate `STOP` is retried up to three times.
3. The native `@opencode-ai/ai/providers/google` package stays the codec, so image, PDF and
   tool-call handling comes from the host rather than a hand-written adapter.

### Four issues found and worked around (may matter for 1.x / pi too)

1. **GPT-OSS tool schemas** — the AGY GPT bridge re-encodes protobuf numeric constraints as
   strings, so `minLength: 1` returns `400 INVALID_ARGUMENT`. Fixed with
   `normalizeGeminiTools(request, { moveNumericConstraintsToDescription: true })` for `gpt-*`
   wire models (the flag already exists in core; it just needs to be enabled for that family).
2. **Strict native event schema** — GPT-OSS opens a turn with `content` and no `parts`, and
   Claude sometimes uses role `assistant`; 2.x rejects both with
   `Invalid google/gemini stream event`. Frames must be normalised before forwarding.
3. **gzip header** — the core transport already inflates the body, so copying upstream
   `content-encoding: gzip` to the host makes it inflate twice and fail.
4. **PDF attachments** — the 2.x CLI drops PDF attachments before the provider sees them (no
   `inlineData` in the request). I therefore register an `antigravity_read_document` tool that
   loads the local PDF/image itself and asks a multimodal model. Images pasted into chat work
   natively. Generated images are written to disk and returned as a text path, because the 2.x
   native parser only renders text and tool calls.

### Verified (Windows 11 / Node 24 / OpenCode 0.0.0-beta-17595 / two-account pool)

- all eight selectors answered live requests, every reasoning tier included:
  Gemini 3.7 / 3.6 / 3.5 Flash, Gemini 3.1 Pro, Gemini 3.1 Flash Image,
  Claude Sonnet 4.6 Thinking, Claude Opus 4.6 Thinking, GPT-OSS 120B;
- tool calling works end to end; PNG attachment recognised; PDF text extracted through the
  tool; image generation written to disk; disabling account `#0` failed over to `#1`.

### Privacy and credentials

- No accounts, e-mail addresses, tokens, project ids or local paths appear in the code or docs.
- Logs contain only `#<account index>`, upstream status codes and routing — no prompts, tokens
  or e-mail addresses.
- Credentials stay in the core-owned `antigravity-accounts.json` (v4 schema + fenced lock),
  shared with the 1.x plugin and the standalone CLI.
- Testing was done locally with my own accounts; no test data is included.

### How you may want to take it

1. I can shape it into `packages/opencode-v2` (or any name you prefer) and open a PR, including
   the bilingual README, an example config and the MIT licence;
2. or you take only the fixes (GPT-OSS schema flag, frame normalisation, gzip header) and I
   split them into small PRs;
3. or I publish it as a separate repository crediting and linking your core.

Whatever suits you. Thanks for the core — its transport and account-pool design made this
adapter straightforward.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/antigravity-auth/pr/13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789644917&installation_model_id=22398&pr_number=13&repository=cortexkit%2Fantigravity-auth&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fantigravity-auth%2Fpull%2F13&signature=e231a313f02cfecc3370122a1dec4b84bc6a0cc12e56dfc88b383b9852aa0ea5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@cortexkit/opencode-v2-antigravity-auth`, a native OpenCode 2.x adapter that restores Antigravity access by rerouting Google model calls to a loopback that reuses the shared core. 2.x previously had no Antigravity support; 1.x behavior is unchanged. Non‑stream `generateContent` now returns a merged JSON response, and generated images are saved to disk.

- Intercepts `/models/*:(stream)generateContent` via `session.hook("http.request")`, forwards to `127.0.0.1`, unwraps SSE frames, normalizes events for the strict 2.x schema, retries bare `STOP` up to 3 times, and merges non‑stream calls into one JSON response.
- Keeps `@opencode-ai/ai/providers/google` as the codec; enables `normalizeGeminiTools(..., { moveNumericConstraintsToDescription: true })` for GPT‑OSS tool schemas.
- Transport and pool: hybrid rotation; 401 forces one refresh then excludes the account; 429/403 cools and rotates (honors `retry-after`); endpoint fallbacks via `ANTIGRAVITY_ENDPOINT_FALLBACKS`.
- Adds `antigravity_read_document` for PDFs/images; by default only files under the user’s home directory are readable, sensitive paths are always denied, the boundary is enforced on the real path (prevents symlink/junction escape), and `readDocumentRoots` are canonicalized and can narrow access.
- OAuth “Google Antigravity (add account)” appends to the shared pool (`antigravity-accounts.json`, v4). Callback listens on `127.0.0.1:51121/oauth-callback`; the callback page only acknowledges receipt.
- Logs to `<state dir>/antigravity-v2.log` without prompts/tokens. Adds example config and tests; includes the package in the publish matrix and `scripts/version-sync.mjs`; typechecks both plugin and callback with `node --check`; tests use `bun test --isolate`.
- Fix: import `resolve` explicitly in the path allowlist to avoid a runtime `ReferenceError`.

**Rollout**
- Requires OpenCode 2.x and `@cortexkit/antigravity-auth-core@2.1.0`.
- Add the plugin to `opencode.json` pointing to `src/plugin.mjs` (absolute path or `node_modules/@cortexkit/opencode-v2-antigravity-auth/src/plugin.mjs`), and declare models under the `google` provider using `@opencode-ai/ai/providers/google`.
- To add accounts: connect the `google` integration and select “Google Antigravity (add account)”; allow localhost access and port 51121.
- Optional: override the pool path with `ANTIGRAVITY_ACCOUNTS_FILE`; set `readDocumentRoots` to restrict document access.

<sup>Written for commit ccd60d91ffa7cceecbd012efea5291ff4abfcee3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/antigravity-auth/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

